### PR TITLE
feat: add MAD, lz, and composite IER detection indices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "insufficient-effort"
-version = "1.2.1"
+version = "1.3.0"
 authors = [{ name = "Cameron Lyons", email = "cameron.lyons2@gmail.com" }]
 description = "Python library for detecting Insufficient Effort Responding (IER) in survey data"
 readme = "README.md"

--- a/src/ier/__init__.py
+++ b/src/ier/__init__.py
@@ -1,11 +1,18 @@
 """IER: Python library for detecting Insufficient Effort Responding in survey data."""
 
 from ._validation import MatrixLike as MatrixLike
+from .composite import composite as composite
+from .composite import composite_flag as composite_flag
+from .composite import composite_summary as composite_summary
 from .evenodd import evenodd as evenodd
 from .guttman import guttman as guttman
 from .guttman import guttman_flag as guttman_flag
 from .irv import irv as irv
 from .longstring import longstring as longstring
+from .lz import lz as lz
+from .lz import lz_flag as lz_flag
+from .mad import mad as mad
+from .mad import mad_flag as mad_flag
 from .mahad import mahad as mahad
 from .person_total import person_total as person_total
 from .psychsyn import psychant as psychant
@@ -23,6 +30,9 @@ from .u3_poly import u3_poly as u3_poly
 
 __all__ = [
     "MatrixLike",
+    "composite",
+    "composite_flag",
+    "composite_summary",
     "evenodd",
     "guttman",
     "guttman_flag",
@@ -30,6 +40,10 @@ __all__ = [
     "individual_reliability_flag",
     "irv",
     "longstring",
+    "lz",
+    "lz_flag",
+    "mad",
+    "mad_flag",
     "mahad",
     "midpoint_responding",
     "person_total",

--- a/src/ier/composite.py
+++ b/src/ier/composite.py
@@ -1,0 +1,316 @@
+"""
+Composite index combining multiple IER detection indices.
+
+Research suggests combining multiple indices improves detection accuracy. The "Best Subset"
+approach (Curran, 2016; Meade & Craig, 2012) recommends combining indices that capture
+different types of careless responding: consistency-based, pattern-based, and outlier-based.
+
+References:
+- Curran, P. G. (2016). Methods for the detection of carelessly invalid responses in
+  survey data. Journal of Experimental Social Psychology, 66, 4-19.
+- Meade, A. W., & Craig, S. B. (2012). Identifying careless responses in survey data.
+  Psychological Methods, 17(3), 437-455.
+"""
+
+import contextlib
+from typing import Any, Literal
+
+import numpy as np
+
+from ier._validation import MatrixLike, validate_matrix_input
+from ier.evenodd import evenodd
+from ier.irv import irv
+from ier.longstring import longstring
+from ier.mahad import mahad
+from ier.person_total import person_total
+from ier.psychsyn import psychsyn
+
+
+def composite(
+    x: MatrixLike,
+    indices: list[str] | None = None,
+    method: Literal["mean", "sum", "max"] = "mean",
+    standardize: bool = True,
+    na_rm: bool = True,
+    psychsyn_critval: float = 0.6,
+    evenodd_factors: list[int] | None = None,
+) -> np.ndarray:
+    """
+    Calculate a composite IER index combining multiple detection methods.
+
+    This function computes multiple IER indices, standardizes them to z-scores,
+    and combines them into a single composite score. Higher composite scores
+    indicate greater likelihood of careless responding.
+
+    Parameters:
+    - x: A matrix of data where rows are individuals and columns are item responses.
+    - indices: List of indices to include. Options: "irv", "longstring", "mahad",
+              "psychsyn", "evenodd", "person_total". Default includes all except
+              evenodd (which requires factor specification).
+    - method: How to combine indices. "mean" (default), "sum", or "max".
+    - standardize: If True (default), standardize each index to z-scores before combining.
+    - na_rm: Handle missing values in individual indices.
+    - psychsyn_critval: Critical correlation value for psychometric synonyms (default 0.6).
+    - evenodd_factors: Factor lengths for even-odd consistency. Required if "evenodd"
+                      is in indices. List of integers where each integer is the number
+                      of items in that factor (e.g., [5, 5, 5] for three 5-item scales).
+
+    Returns:
+    - A numpy array of composite scores for each individual. Higher scores indicate
+      greater likelihood of careless responding.
+
+    Raises:
+    - ValueError: If invalid indices specified or evenodd requested without factors.
+
+    Example:
+        >>> data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3], [5, 4, 3, 2, 1]]
+        >>> scores = composite(data)
+        >>> print(scores)
+        [-0.5, 1.2, -0.3]
+
+        >>> scores = composite(data, indices=["irv", "longstring"])
+        >>> print(scores)
+        [-0.7, 1.5, -0.2]
+    """
+    x_array = validate_matrix_input(x, check_type=False)
+
+    valid_indices = {"irv", "longstring", "mahad", "psychsyn", "evenodd", "person_total"}
+
+    if indices is None:
+        indices = ["irv", "longstring", "mahad", "psychsyn", "person_total"]
+
+    for idx in indices:
+        if idx not in valid_indices:
+            raise ValueError(f"invalid index '{idx}'. Valid options: {valid_indices}")
+
+    if "evenodd" in indices and evenodd_factors is None:
+        raise ValueError("evenodd_factors must be provided when using evenodd index")
+
+    if method not in ["mean", "sum", "max"]:
+        raise ValueError("method must be 'mean', 'sum', or 'max'")
+
+    index_scores: dict[str, np.ndarray] = {}
+
+    if "irv" in indices:
+        irv_scores = irv(x_array, na_rm=na_rm)
+        index_scores["irv"] = -irv_scores
+
+    if "longstring" in indices:
+        response_strings = [
+            "".join(str(int(v)) if not np.isnan(v) else "" for v in row) for row in x_array
+        ]
+        ls_results = longstring(response_strings)
+        ls_scores = np.array([r[1] if r is not None else 0 for r in ls_results], dtype=float)
+        index_scores["longstring"] = ls_scores
+
+    if "mahad" in indices:
+        with contextlib.suppress(ValueError):
+            mahad_result = mahad(x_array, na_rm=na_rm)
+            if isinstance(mahad_result, np.ndarray):
+                index_scores["mahad"] = mahad_result
+
+    if "psychsyn" in indices:
+        with contextlib.suppress(ValueError), np.errstate(divide="ignore", invalid="ignore"):
+            psyn_result = psychsyn(x_array, critval=psychsyn_critval, resample_na=na_rm)
+            if isinstance(psyn_result, np.ndarray):
+                index_scores["psychsyn"] = -psyn_result
+
+    if "evenodd" in indices and evenodd_factors is not None:
+        with contextlib.suppress(ValueError):
+            eo_result = evenodd(x_array, factors=evenodd_factors)
+            if isinstance(eo_result, np.ndarray):
+                index_scores["evenodd"] = -eo_result
+
+    if "person_total" in indices:
+        with contextlib.suppress(ValueError):
+            index_scores["person_total"] = -person_total(x_array, na_rm=na_rm)
+
+    if len(index_scores) == 0:
+        raise ValueError("no valid indices could be computed from the data")
+
+    if standardize:
+        standardized_scores = {}
+        for name, scores in index_scores.items():
+            valid_mask = ~np.isnan(scores)
+            if np.sum(valid_mask) > 1:
+                mean_val = np.nanmean(scores)
+                std_val = np.nanstd(scores)
+                if std_val > 0:
+                    standardized_scores[name] = (scores - mean_val) / std_val
+                else:
+                    standardized_scores[name] = np.zeros_like(scores)
+            else:
+                standardized_scores[name] = scores
+        index_scores = standardized_scores
+
+    score_matrix = np.column_stack(list(index_scores.values()))
+
+    if method == "mean":
+        result: np.ndarray = np.nanmean(score_matrix, axis=1)
+    elif method == "sum":
+        result = np.nansum(score_matrix, axis=1)
+    else:
+        result = np.nanmax(score_matrix, axis=1)
+
+    return result
+
+
+def composite_flag(
+    x: MatrixLike,
+    indices: list[str] | None = None,
+    method: Literal["mean", "sum", "max"] = "mean",
+    threshold: float | None = None,
+    percentile: float = 95.0,
+    standardize: bool = True,
+    na_rm: bool = True,
+    psychsyn_critval: float = 0.6,
+    evenodd_factors: list[int] | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Calculate composite IER scores and flag potential careless responders.
+
+    Parameters:
+    - x: A matrix of data where rows are individuals and columns are item responses.
+    - indices: List of indices to include (see composite() for options).
+    - method: How to combine indices ("mean", "sum", or "max").
+    - threshold: Absolute threshold above which to flag. If None, uses percentile.
+    - percentile: Percentile cutoff for flagging (default 95th percentile).
+    - standardize: Standardize indices to z-scores before combining.
+    - na_rm: Handle missing values.
+    - psychsyn_critval: Critical value for psychometric synonyms.
+    - evenodd_factors: Factor structure for even-odd consistency.
+
+    Returns:
+    - Tuple of (composite_scores, flags) where flags is True for suspected
+      careless responders.
+
+    Example:
+        >>> data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3], [5, 4, 3, 2, 1]]
+        >>> scores, flags = composite_flag(data)
+        >>> print(flags)
+        [False, True, False]
+    """
+    scores = composite(
+        x,
+        indices=indices,
+        method=method,
+        standardize=standardize,
+        na_rm=na_rm,
+        psychsyn_critval=psychsyn_critval,
+        evenodd_factors=evenodd_factors,
+    )
+
+    valid_scores = scores[~np.isnan(scores)]
+
+    if threshold is None:
+        if len(valid_scores) == 0:
+            threshold = 0.0
+        else:
+            threshold = float(np.percentile(valid_scores, percentile))
+
+    flags = np.zeros(len(scores), dtype=bool)
+    valid_mask = ~np.isnan(scores)
+    flags[valid_mask] = scores[valid_mask] > threshold
+
+    return scores, flags
+
+
+def composite_summary(
+    x: MatrixLike,
+    indices: list[str] | None = None,
+    method: Literal["mean", "sum", "max"] = "mean",
+    standardize: bool = True,
+    na_rm: bool = True,
+    psychsyn_critval: float = 0.6,
+    evenodd_factors: list[int] | None = None,
+) -> dict[str, Any]:
+    """
+    Calculate composite scores with detailed summary statistics.
+
+    Parameters:
+    - x: A matrix of data where rows are individuals and columns are item responses.
+    - indices: List of indices to include.
+    - method: Combination method.
+    - standardize: Standardize before combining.
+    - na_rm: Handle missing values.
+    - psychsyn_critval: Critical value for psychometric synonyms.
+    - evenodd_factors: Factor structure for even-odd consistency.
+
+    Returns:
+    - Dictionary with composite scores, individual index scores, and statistics.
+
+    Example:
+        >>> data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3], [5, 4, 3, 2, 1]]
+        >>> summary = composite_summary(data)
+        >>> print(summary.keys())
+        dict_keys(['composite', 'indices', 'mean', 'std', 'min', 'max', ...])
+    """
+    x_array = validate_matrix_input(x, check_type=False)
+
+    if indices is None:
+        indices = ["irv", "longstring", "mahad", "psychsyn", "person_total"]
+
+    if "evenodd" in indices and evenodd_factors is None:
+        raise ValueError("evenodd_factors must be provided when using evenodd index")
+
+    individual_scores: dict[str, np.ndarray] = {}
+
+    if "irv" in indices:
+        individual_scores["irv"] = irv(x_array, na_rm=na_rm)
+
+    if "longstring" in indices:
+        response_strings = [
+            "".join(str(int(v)) if not np.isnan(v) else "" for v in row) for row in x_array
+        ]
+        ls_results = longstring(response_strings)
+        individual_scores["longstring"] = np.array(
+            [r[1] if r is not None else 0 for r in ls_results], dtype=float
+        )
+
+    if "mahad" in indices:
+        with contextlib.suppress(ValueError):
+            mahad_result = mahad(x_array, na_rm=na_rm)
+            if isinstance(mahad_result, np.ndarray):
+                individual_scores["mahad"] = mahad_result
+
+    if "psychsyn" in indices:
+        with contextlib.suppress(ValueError), np.errstate(divide="ignore", invalid="ignore"):
+            psyn_result = psychsyn(x_array, critval=psychsyn_critval, resample_na=na_rm)
+            if isinstance(psyn_result, np.ndarray):
+                individual_scores["psychsyn"] = psyn_result
+
+    if "evenodd" in indices and evenodd_factors is not None:
+        with contextlib.suppress(ValueError):
+            eo_result = evenodd(x_array, factors=evenodd_factors)
+            if isinstance(eo_result, np.ndarray):
+                individual_scores["evenodd"] = eo_result
+
+    if "person_total" in indices:
+        with contextlib.suppress(ValueError):
+            individual_scores["person_total"] = person_total(x_array, na_rm=na_rm)
+
+    composite_scores = composite(
+        x_array,
+        indices=indices,
+        method=method,
+        standardize=standardize,
+        na_rm=na_rm,
+        psychsyn_critval=psychsyn_critval,
+        evenodd_factors=evenodd_factors,
+    )
+
+    valid_composite = composite_scores[~np.isnan(composite_scores)]
+
+    return {
+        "composite": composite_scores,
+        "indices": individual_scores,
+        "indices_used": list(individual_scores.keys()),
+        "method": method,
+        "standardized": standardize,
+        "mean": float(np.nanmean(composite_scores)) if len(valid_composite) > 0 else np.nan,
+        "std": float(np.nanstd(composite_scores)) if len(valid_composite) > 0 else np.nan,
+        "min": float(np.nanmin(composite_scores)) if len(valid_composite) > 0 else np.nan,
+        "max": float(np.nanmax(composite_scores)) if len(valid_composite) > 0 else np.nan,
+        "n_total": len(composite_scores),
+        "n_valid": int(np.sum(~np.isnan(composite_scores))),
+    }

--- a/src/ier/lz.py
+++ b/src/ier/lz.py
@@ -1,0 +1,304 @@
+"""
+Standardized Log-Likelihood (lz) person-fit statistic for detecting aberrant response patterns.
+
+The lz statistic is an IRT-based person-fit index that measures the discrepancy between
+observed and expected response patterns. Under proper conditions, lz approximately follows
+a standard normal distribution, with negative values indicating responses that are
+inconsistent with the expected pattern.
+
+References:
+- Drasgow, F., Levine, M. V., & Williams, E. A. (1985). Appropriateness measurement with
+  polychotomous item response models and standardized indices. British Journal of
+  Mathematical and Statistical Psychology, 38(1), 67-86.
+- Meijer, R. R., & Sijtsma, K. (2001). Methodology review: Evaluating person fit.
+  Applied Psychological Measurement, 25(2), 107-135.
+"""
+
+import logging
+
+import numpy as np
+
+from ier._validation import MatrixLike, validate_matrix_input
+
+logger = logging.getLogger(__name__)
+
+SCIPY_AVAILABLE = False
+try:
+    from scipy import optimize
+
+    SCIPY_AVAILABLE = True
+except ImportError as e:
+    # SciPy is optional; ML theta estimation falls back to logit transformation
+    logger.debug("SciPy not available, ML theta estimation disabled: %s", e)
+
+
+def lz(
+    x: MatrixLike,
+    difficulty: np.ndarray | list[float] | None = None,
+    discrimination: np.ndarray | list[float] | None = None,
+    theta: np.ndarray | list[float] | None = None,
+    model: str = "2pl",
+    na_rm: bool = True,
+) -> np.ndarray:
+    """
+    Calculate standardized log-likelihood (lz) person-fit statistic.
+
+    The lz statistic measures how well each person's response pattern fits the
+    expected pattern under an Item Response Theory (IRT) model. Negative values
+    indicate aberrant or unexpected response patterns, potentially suggesting
+    careless or random responding.
+
+    Parameters:
+    - x: A matrix of dichotomous data (0/1) where rows are individuals and
+         columns are items. For polytomous data, responses will be dichotomized
+         at the midpoint.
+    - difficulty: Array of item difficulty parameters (b). If None, estimated from data.
+    - discrimination: Array of item discrimination parameters (a). If None and model="2pl",
+                     estimated from data. Ignored if model="1pl".
+    - theta: Array of person ability estimates. If None, estimated from data.
+    - model: IRT model to use. "1pl" (Rasch) or "2pl" (default).
+    - na_rm: Boolean indicating whether to handle missing values.
+
+    Returns:
+    - A numpy array of lz values for each individual. Values significantly below
+      -1.96 may indicate careless responding (at alpha=0.05).
+
+    Raises:
+    - ValueError: If inputs are invalid.
+
+    Example:
+        >>> data = [[1, 1, 0, 0, 1], [1, 0, 0, 0, 0], [0, 0, 0, 0, 0]]
+        >>> lz_scores = lz(data)
+        >>> print(lz_scores)
+        [0.12, -0.45, -2.31]
+    """
+    x_array = validate_matrix_input(x, check_type=False)
+
+    if model not in ["1pl", "2pl"]:
+        raise ValueError("model must be '1pl' or '2pl'")
+
+    x_binary = _dichotomize(x_array)
+
+    if difficulty is not None:
+        b = np.asarray(difficulty)
+        if len(b) != x_array.shape[1]:
+            raise ValueError("difficulty length must match number of items")
+    else:
+        b = _estimate_difficulty(x_binary, na_rm=na_rm)
+
+    if model == "2pl":
+        if discrimination is not None:
+            a = np.asarray(discrimination)
+            if len(a) != x_array.shape[1]:
+                raise ValueError("discrimination length must match number of items")
+        else:
+            a = _estimate_discrimination(x_binary, b, na_rm=na_rm)
+    else:
+        a = np.ones(x_array.shape[1])
+
+    if theta is not None:
+        theta_arr = np.asarray(theta)
+        if len(theta_arr) != x_array.shape[0]:
+            raise ValueError("theta length must match number of respondents")
+    else:
+        theta_arr = _estimate_theta(x_binary, a, b, na_rm=na_rm)
+
+    lz_values = _compute_lz(x_binary, a, b, theta_arr, na_rm=na_rm)
+
+    return lz_values
+
+
+def lz_flag(
+    x: MatrixLike,
+    difficulty: np.ndarray | list[float] | None = None,
+    discrimination: np.ndarray | list[float] | None = None,
+    theta: np.ndarray | list[float] | None = None,
+    model: str = "2pl",
+    threshold: float = -1.96,
+    na_rm: bool = True,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Calculate lz scores and flag potential careless responders.
+
+    Parameters:
+    - x: A matrix of dichotomous data (0/1).
+    - difficulty: Array of item difficulty parameters.
+    - discrimination: Array of item discrimination parameters.
+    - theta: Array of person ability estimates.
+    - model: IRT model ("1pl" or "2pl").
+    - threshold: lz threshold below which to flag (default -1.96 for alpha=0.05).
+    - na_rm: Handle missing values.
+
+    Returns:
+    - Tuple of (lz_scores, flags) where flags is True for suspected careless responders.
+
+    Example:
+        >>> data = [[1, 1, 0, 0, 1], [1, 0, 0, 0, 0], [0, 0, 0, 0, 0]]
+        >>> scores, flags = lz_flag(data)
+        >>> print(flags)
+        [False, False, True]
+    """
+    scores = lz(
+        x,
+        difficulty=difficulty,
+        discrimination=discrimination,
+        theta=theta,
+        model=model,
+        na_rm=na_rm,
+    )
+
+    flags = np.zeros(len(scores), dtype=bool)
+    valid_mask = ~np.isnan(scores)
+    flags[valid_mask] = scores[valid_mask] < threshold
+
+    return scores, flags
+
+
+def _dichotomize(x: np.ndarray) -> np.ndarray:
+    """Dichotomize polytomous responses at the midpoint."""
+    unique_vals = np.unique(x[~np.isnan(x)])
+    if len(unique_vals) <= 2 and np.all(np.isin(unique_vals, [0, 1])):
+        return x.copy()
+
+    midpoint = (np.nanmax(x) + np.nanmin(x)) / 2
+    result = np.where(np.isnan(x), np.nan, (x > midpoint).astype(float))
+    return result
+
+
+def _estimate_difficulty(x: np.ndarray, na_rm: bool = True) -> np.ndarray:
+    """Estimate item difficulty from proportion correct."""
+    p = np.nanmean(x, axis=0) if na_rm else np.mean(x, axis=0)
+    p = np.clip(p, 0.001, 0.999)
+    b: np.ndarray = -np.log(p / (1 - p))
+    return b
+
+
+def _estimate_discrimination(x: np.ndarray, b: np.ndarray, na_rm: bool = True) -> np.ndarray:
+    """Estimate item discrimination using point-biserial correlation."""
+    n_items = x.shape[1]
+    a = np.ones(n_items)
+
+    total_score = np.nansum(x, axis=1) if na_rm else np.sum(x, axis=1)
+
+    if np.std(total_score) == 0:
+        return a
+
+    for j in range(n_items):
+        if na_rm:
+            valid_mask = ~np.isnan(x[:, j])
+            item_resp = x[valid_mask, j]
+            scores = total_score[valid_mask]
+        else:
+            item_resp = x[:, j]
+            scores = total_score
+
+        if len(np.unique(item_resp)) < 2:
+            continue
+
+        if np.std(scores) == 0:
+            continue
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            corr_matrix = np.corrcoef(item_resp, scores)
+            r_pb = corr_matrix[0, 1]
+
+        if np.isnan(r_pb):
+            continue
+
+        r_pb = np.clip(r_pb, -0.99, 0.99)
+        a[j] = r_pb * 1.7 / np.sqrt(1 - r_pb**2)
+        a[j] = np.clip(a[j], 0.2, 3.0)
+
+    return a
+
+
+def _estimate_theta(x: np.ndarray, a: np.ndarray, b: np.ndarray, na_rm: bool = True) -> np.ndarray:
+    """Estimate person ability using ML or sum score transformation."""
+    n_persons = x.shape[0]
+    theta = np.zeros(n_persons)
+
+    for i in range(n_persons):
+        if na_rm:
+            valid_mask = ~np.isnan(x[i, :])
+            responses = x[i, valid_mask]
+            a_valid = a[valid_mask]
+            b_valid = b[valid_mask]
+        else:
+            responses = x[i, :]
+            a_valid = a
+            b_valid = b
+
+        if len(responses) == 0:
+            theta[i] = np.nan
+            continue
+
+        if np.all(responses == 1):
+            theta[i] = 3.0
+        elif np.all(responses == 0):
+            theta[i] = -3.0
+        elif SCIPY_AVAILABLE:
+            theta[i] = _ml_theta(responses, a_valid, b_valid)
+        else:
+            p = np.mean(responses)
+            p = np.clip(p, 0.01, 0.99)
+            theta[i] = np.log(p / (1 - p))
+
+    return theta
+
+
+def _ml_theta(responses: np.ndarray, a: np.ndarray, b: np.ndarray) -> float:
+    """Maximum likelihood estimation of theta for a single person."""
+
+    def neg_log_likelihood(theta_val: float) -> float:
+        prob = 1 / (1 + np.exp(-a * (theta_val - b)))
+        prob = np.clip(prob, 1e-10, 1 - 1e-10)
+        ll: float = float(np.sum(responses * np.log(prob) + (1 - responses) * np.log(1 - prob)))
+        return -ll
+
+    result = optimize.minimize_scalar(neg_log_likelihood, bounds=(-4, 4), method="bounded")
+    x_val: float = float(result.x)
+    return x_val
+
+
+def _compute_lz(
+    x: np.ndarray, a: np.ndarray, b: np.ndarray, theta: np.ndarray, na_rm: bool = True
+) -> np.ndarray:
+    """Compute standardized log-likelihood for each person."""
+    n_persons = x.shape[0]
+    lz_values = np.zeros(n_persons)
+
+    for i in range(n_persons):
+        if np.isnan(theta[i]):
+            lz_values[i] = np.nan
+            continue
+
+        if na_rm:
+            valid_mask = ~np.isnan(x[i, :])
+            responses = x[i, valid_mask]
+            a_valid = a[valid_mask]
+            b_valid = b[valid_mask]
+        else:
+            responses = x[i, :]
+            a_valid = a
+            b_valid = b
+
+        if len(responses) == 0:
+            lz_values[i] = np.nan
+            continue
+
+        prob = 1 / (1 + np.exp(-a_valid * (theta[i] - b_valid)))
+        prob = np.clip(prob, 1e-10, 1 - 1e-10)
+
+        log_l = np.sum(responses * np.log(prob) + (1 - responses) * np.log(1 - prob))
+
+        expected_l = np.sum(prob * np.log(prob) + (1 - prob) * np.log(1 - prob))
+
+        log_odds = np.log(prob / (1 - prob))
+        var_l = np.sum(prob * (1 - prob) * log_odds**2)
+
+        if var_l <= 0:
+            lz_values[i] = 0.0
+        else:
+            lz_values[i] = (log_l - expected_l) / np.sqrt(var_l)
+
+    return lz_values

--- a/src/ier/mad.py
+++ b/src/ier/mad.py
@@ -1,0 +1,158 @@
+"""
+Mean Absolute Difference (MAD) for detecting insufficient effort responding.
+
+MAD calculates the average absolute difference between responses to positively and negatively
+worded (reverse-coded) items. This helps detect respondents who fail to adjust their responses
+for reverse-worded items, indicating inattentive or careless responding.
+
+References:
+- Huang, J. L., Curran, P. G., Keeney, J., Poposki, E. M., & DeShon, R. P. (2012).
+  Detecting and deterring insufficient effort responding to surveys.
+  Journal of Business and Psychology, 27(1), 99-114.
+"""
+
+import numpy as np
+
+from ier._validation import MatrixLike, validate_matrix_input
+
+
+def mad(
+    x: MatrixLike,
+    positive_items: list[int] | None = None,
+    negative_items: list[int] | None = None,
+    item_pairs: list[tuple[int, int]] | None = None,
+    scale_max: int | None = None,
+    na_rm: bool = True,
+) -> np.ndarray:
+    """
+    Calculate Mean Absolute Difference (MAD) for detecting careless responding.
+
+    MAD measures the average absolute difference between responses to positively-worded
+    and reverse-coded (negatively-worded) items. Higher MAD scores indicate greater
+    consistency with item direction, while low MAD scores may indicate careless
+    responding where participants fail to attend to reverse-coded items.
+
+    Parameters:
+    - x: A matrix of data where rows are individuals and columns are item responses.
+         Can be a 2D list or numpy array. Responses should NOT be pre-reversed.
+    - positive_items: List of column indices (0-based) for positively-worded items.
+    - negative_items: List of column indices (0-based) for negatively-worded items.
+                     These items will be reverse-scored before comparison.
+    - item_pairs: Alternative to positive/negative_items. List of (positive, negative)
+                 index tuples representing paired items to compare.
+    - scale_max: Maximum value of the response scale (required for reverse scoring).
+                If None, inferred from max value in the data.
+    - na_rm: Boolean indicating whether to ignore missing values during computation.
+
+    Returns:
+    - A numpy array of MAD scores for each individual. Lower scores suggest
+      careless responding (not attending to item direction).
+
+    Raises:
+    - ValueError: If inputs are invalid or item indices are out of bounds.
+
+    Example:
+        >>> data = [[5, 1, 4, 2], [3, 3, 3, 3], [5, 2, 4, 1]]
+        >>> mad_scores = mad(data, positive_items=[0, 2], negative_items=[1, 3], scale_max=5)
+        >>> print(mad_scores)
+        [0.5, 2.0, 0.75]
+    """
+    x_array = validate_matrix_input(x, check_type=False)
+    n_cols = x_array.shape[1]
+
+    if item_pairs is not None:
+        if positive_items is not None or negative_items is not None:
+            raise ValueError("cannot specify both item_pairs and positive/negative_items")
+        positive_items = [p[0] for p in item_pairs]
+        negative_items = [p[1] for p in item_pairs]
+
+    if positive_items is None or negative_items is None:
+        raise ValueError("must specify either item_pairs or both positive_items and negative_items")
+
+    if len(positive_items) == 0 or len(negative_items) == 0:
+        raise ValueError("positive_items and negative_items cannot be empty")
+
+    for idx in positive_items + negative_items:
+        if idx < 0 or idx >= n_cols:
+            raise ValueError(f"item index {idx} out of bounds for data with {n_cols} columns")
+
+    if scale_max is None:
+        scale_max = int(np.nanmax(x_array))
+
+    scale_min = int(np.nanmin(x_array[~np.isnan(x_array)]))
+
+    positive_responses = x_array[:, positive_items].astype(float)
+    negative_responses = x_array[:, negative_items].astype(float)
+
+    reversed_negative = (scale_max + scale_min) - negative_responses
+
+    min_len = min(len(positive_items), len(negative_items))
+    positive_subset = positive_responses[:, :min_len]
+    reversed_subset = reversed_negative[:, :min_len]
+
+    abs_diff = np.abs(positive_subset - reversed_subset)
+
+    if na_rm:
+        result: np.ndarray = np.nanmean(abs_diff, axis=1)
+    else:
+        result = np.mean(abs_diff, axis=1)
+
+    return result
+
+
+def mad_flag(
+    x: MatrixLike,
+    positive_items: list[int] | None = None,
+    negative_items: list[int] | None = None,
+    item_pairs: list[tuple[int, int]] | None = None,
+    scale_max: int | None = None,
+    threshold: float | None = None,
+    percentile: float = 95.0,
+    na_rm: bool = True,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Calculate MAD scores and flag potential careless responders.
+
+    High MAD scores indicate careless responding (not attending to item direction).
+
+    Parameters:
+    - x: A matrix of data where rows are individuals and columns are item responses.
+    - positive_items: List of column indices for positively-worded items.
+    - negative_items: List of column indices for negatively-worded items.
+    - item_pairs: Alternative list of (positive, negative) index tuples.
+    - scale_max: Maximum value of the response scale.
+    - threshold: Absolute MAD threshold above which to flag. If None, uses percentile.
+    - percentile: Percentile cutoff for flagging (default 95th percentile).
+    - na_rm: Boolean indicating whether to ignore missing values.
+
+    Returns:
+    - Tuple of (mad_scores, flags) where flags is True for suspected careless responders.
+
+    Example:
+        >>> data = [[5, 1, 4, 2], [5, 5, 5, 5], [5, 2, 4, 1]]
+        >>> scores, flags = mad_flag(data, positive_items=[0, 2], negative_items=[1, 3])
+        >>> print(flags)
+        [False, True, False]
+    """
+    scores = mad(
+        x,
+        positive_items=positive_items,
+        negative_items=negative_items,
+        item_pairs=item_pairs,
+        scale_max=scale_max,
+        na_rm=na_rm,
+    )
+
+    valid_scores = scores[~np.isnan(scores)]
+
+    if threshold is None:
+        if len(valid_scores) == 0:
+            threshold = 0.0
+        else:
+            threshold = float(np.percentile(valid_scores, percentile))
+
+    flags = np.zeros(len(scores), dtype=bool)
+    valid_mask = ~np.isnan(scores)
+    flags[valid_mask] = scores[valid_mask] > threshold
+
+    return scores, flags

--- a/tests/test_new_functions.py
+++ b/tests/test_new_functions.py
@@ -440,7 +440,10 @@ class TestLz(unittest.TestCase):
         ]
         scores, flags = lz_flag(data, threshold=-1.5)
         self.assertEqual(len(flags), 2)
-        self.assertTrue(flags.dtype == bool)
+        self.assertTrue(
+            np.issubdtype(flags.dtype, np.bool_),
+            msg=f"Expected boolean dtype, got {flags.dtype}",
+        )
 
     def test_flag_with_custom_threshold(self) -> None:
         """Test lz flagging with custom threshold."""

--- a/tests/test_new_functions.py
+++ b/tests/test_new_functions.py
@@ -4,7 +4,10 @@ import unittest
 
 import numpy as np
 
+from ier.composite import composite, composite_flag, composite_summary
 from ier.guttman import guttman, guttman_flag
+from ier.lz import lz, lz_flag
+from ier.mad import mad, mad_flag
 from ier.person_total import person_total
 from ier.reliability import individual_reliability, individual_reliability_flag
 from ier.response_time import (
@@ -176,6 +179,317 @@ class TestU3Poly(unittest.TestCase):
         self.assertIn("midpoint", result)
         self.assertIn("acquiescence", result)
         self.assertIn("variability", result)
+
+
+class TestComposite(unittest.TestCase):
+    """Tests for composite IER index functions."""
+
+    def test_basic_functionality(self) -> None:
+        """Test basic composite calculation."""
+        data = [
+            [1, 2, 3, 4, 5, 4, 3, 2, 1, 2],
+            [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            [5, 4, 3, 2, 1, 2, 3, 4, 5, 4],
+        ]
+        result = composite(data)
+        self.assertEqual(len(result), 3)
+
+    def test_straightliner_highest_score(self) -> None:
+        """Test that straightliners get highest composite score."""
+        data = [
+            [1, 2, 3, 4, 5, 4, 3, 2, 1, 2],
+            [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            [5, 4, 3, 2, 1, 2, 3, 4, 5, 4],
+        ]
+        result = composite(data)
+        self.assertEqual(np.argmax(result), 1)
+
+    def test_specific_indices(self) -> None:
+        """Test composite with specific indices."""
+        data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3], [5, 4, 3, 2, 1]]
+        result = composite(data, indices=["irv", "longstring"])
+        self.assertEqual(len(result), 3)
+
+    def test_sum_method(self) -> None:
+        """Test composite with sum method."""
+        data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3]]
+        result = composite(data, method="sum")
+        self.assertEqual(len(result), 2)
+
+    def test_max_method(self) -> None:
+        """Test composite with max method."""
+        data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3]]
+        result = composite(data, method="max")
+        self.assertEqual(len(result), 2)
+
+    def test_no_standardize(self) -> None:
+        """Test composite without standardization."""
+        data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3]]
+        result = composite(data, standardize=False)
+        self.assertEqual(len(result), 2)
+
+    def test_with_evenodd(self) -> None:
+        """Test composite with evenodd index."""
+        data = [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [3, 3, 3, 3, 3, 3, 3, 3, 3, 3]]
+        result = composite(data, indices=["irv", "evenodd"], evenodd_factors=[5, 5])
+        self.assertEqual(len(result), 2)
+
+    def test_flag_function(self) -> None:
+        """Test composite flagging."""
+        data = [
+            [1, 2, 3, 4, 5, 4, 3, 2, 1, 2],
+            [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            [5, 4, 3, 2, 1, 2, 3, 4, 5, 4],
+        ]
+        scores, flags = composite_flag(data, threshold=1.0)
+        self.assertEqual(len(flags), 3)
+        self.assertTrue(flags.dtype == bool)
+        self.assertTrue(flags[1])
+
+    def test_flag_with_percentile(self) -> None:
+        """Test composite flagging with percentile."""
+        data = [
+            [1, 2, 3, 4, 5],
+            [3, 3, 3, 3, 3],
+            [5, 4, 3, 2, 1],
+            [2, 3, 4, 5, 1],
+        ]
+        scores, flags = composite_flag(data, percentile=75.0)
+        self.assertEqual(len(flags), 4)
+
+    def test_summary_function(self) -> None:
+        """Test composite summary."""
+        data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3], [5, 4, 3, 2, 1]]
+        summary = composite_summary(data)
+        self.assertIn("composite", summary)
+        self.assertIn("indices", summary)
+        self.assertIn("indices_used", summary)
+        self.assertIn("mean", summary)
+        self.assertIn("std", summary)
+
+    def test_invalid_index_raises(self) -> None:
+        """Test that invalid index raises ValueError."""
+        data = [[1, 2, 3, 4, 5]]
+        with self.assertRaises(ValueError):
+            composite(data, indices=["invalid_index"])
+
+    def test_evenodd_without_factors_raises(self) -> None:
+        """Test that evenodd without factors raises ValueError."""
+        data = [[1, 2, 3, 4, 5]]
+        with self.assertRaises(ValueError):
+            composite(data, indices=["evenodd"])
+
+    def test_invalid_method_raises(self) -> None:
+        """Test that invalid method raises ValueError."""
+        data = [[1, 2, 3, 4, 5]]
+        with self.assertRaises(ValueError):
+            composite(data, method="invalid")  # type: ignore[arg-type]
+
+
+class TestMAD(unittest.TestCase):
+    """Tests for Mean Absolute Difference functions."""
+
+    def test_basic_functionality(self) -> None:
+        """Test basic MAD calculation."""
+        data = [
+            [5, 1, 5, 1],
+            [5, 5, 5, 5],
+            [3, 3, 3, 3],
+        ]
+        result = mad(data, positive_items=[0, 2], negative_items=[1, 3], scale_max=5)
+        self.assertEqual(len(result), 3)
+        self.assertAlmostEqual(result[0], 0.0)
+        self.assertAlmostEqual(result[1], 4.0)
+        self.assertAlmostEqual(result[2], 0.0)
+
+    def test_attentive_responder(self) -> None:
+        """Test that attentive responders get low MAD."""
+        data = [[5, 1, 4, 2], [4, 2, 5, 1]]
+        result = mad(data, positive_items=[0, 2], negative_items=[1, 3], scale_max=5)
+        for score in result:
+            self.assertLess(score, 1.0)
+
+    def test_careless_responder_high_mad(self) -> None:
+        """Test that careless responders ignoring item direction get high MAD."""
+        data = [[5, 5, 5, 5], [1, 1, 1, 1]]
+        result = mad(data, positive_items=[0, 2], negative_items=[1, 3], scale_max=5)
+        for score in result:
+            self.assertGreater(score, 3.0)
+
+    def test_item_pairs_input(self) -> None:
+        """Test using item_pairs instead of positive/negative items."""
+        data = [[5, 1, 4, 2], [3, 3, 3, 3]]
+        pairs = [(0, 1), (2, 3)]
+        result = mad(data, item_pairs=pairs, scale_max=5)
+        self.assertEqual(len(result), 2)
+
+    def test_flag_function(self) -> None:
+        """Test MAD flagging."""
+        data = [
+            [5, 1, 5, 1],
+            [5, 5, 5, 5],
+            [3, 3, 3, 3],
+        ]
+        scores, flags = mad_flag(
+            data, positive_items=[0, 2], negative_items=[1, 3], scale_max=5, threshold=3.0
+        )
+        self.assertEqual(len(flags), 3)
+        self.assertTrue(flags.dtype == bool)
+        self.assertTrue(flags[1])
+        self.assertFalse(flags[0])
+
+    def test_with_nan(self) -> None:
+        """Test handling of missing values."""
+        data = [[5, 1, np.nan, 1], [5, 5, 5, 5]]
+        result = mad(data, positive_items=[0, 2], negative_items=[1, 3], scale_max=5, na_rm=True)
+        self.assertEqual(len(result), 2)
+        self.assertFalse(np.isnan(result[0]))
+
+    def test_invalid_no_items_raises(self) -> None:
+        """Test that missing item specification raises ValueError."""
+        data = [[1, 2, 3, 4]]
+        with self.assertRaises(ValueError):
+            mad(data, positive_items=[0, 1])
+
+    def test_invalid_index_raises(self) -> None:
+        """Test that out-of-bounds index raises ValueError."""
+        data = [[1, 2, 3, 4]]
+        with self.assertRaises(ValueError):
+            mad(data, positive_items=[0, 10], negative_items=[1, 2], scale_max=5)
+
+    def test_both_item_specs_raises(self) -> None:
+        """Test that specifying both item_pairs and positive/negative raises."""
+        data = [[1, 2, 3, 4]]
+        with self.assertRaises(ValueError):
+            mad(data, positive_items=[0], negative_items=[1], item_pairs=[(0, 1)], scale_max=5)
+
+    def test_scale_max_inference(self) -> None:
+        """Test that scale_max is inferred from data when not provided."""
+        data = [[5, 1, 5, 1], [3, 3, 3, 3]]
+        result = mad(data, positive_items=[0, 2], negative_items=[1, 3])
+        self.assertEqual(len(result), 2)
+
+
+class TestLz(unittest.TestCase):
+    """Tests for standardized log-likelihood (lz) functions."""
+
+    def test_basic_functionality(self) -> None:
+        """Test basic lz calculation."""
+        data = [
+            [1, 1, 1, 0, 0, 0, 0, 0],
+            [1, 0, 1, 0, 1, 0, 1, 0],
+            [0, 0, 0, 0, 1, 1, 1, 1],
+        ]
+        result = lz(data)
+        self.assertEqual(len(result), 3)
+
+    def test_normal_pattern_positive_lz(self) -> None:
+        """Test that normal response patterns get non-negative lz."""
+        data = [
+            [1, 1, 1, 1, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0, 0, 0],
+        ]
+        result = lz(data)
+        for score in result:
+            self.assertGreater(score, -2.0)
+
+    def test_aberrant_pattern_negative_lz(self) -> None:
+        """Test that aberrant patterns tend toward negative lz."""
+        data = [
+            [1, 1, 1, 1, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 1, 1, 1],
+        ]
+        lz_scores = lz(data)
+        self.assertGreater(lz_scores[0], lz_scores[3])
+
+    def test_1pl_model(self) -> None:
+        """Test lz with 1PL (Rasch) model."""
+        data = [[1, 1, 0, 0], [1, 0, 1, 0]]
+        result = lz(data, model="1pl")
+        self.assertEqual(len(result), 2)
+
+    def test_2pl_model(self) -> None:
+        """Test lz with 2PL model (default)."""
+        data = [[1, 1, 0, 0], [1, 0, 1, 0]]
+        result = lz(data, model="2pl")
+        self.assertEqual(len(result), 2)
+
+    def test_custom_parameters(self) -> None:
+        """Test lz with user-specified item parameters."""
+        data = [[1, 1, 0, 0], [0, 1, 1, 0]]
+        difficulty = [-1.0, -0.5, 0.5, 1.0]
+        discrimination = [1.0, 1.0, 1.0, 1.0]
+        result = lz(data, difficulty=difficulty, discrimination=discrimination)
+        self.assertEqual(len(result), 2)
+
+    def test_custom_theta(self) -> None:
+        """Test lz with user-specified theta values."""
+        data = [[1, 1, 0, 0], [0, 1, 1, 0]]
+        theta = [0.0, 0.5]
+        result = lz(data, theta=theta)
+        self.assertEqual(len(result), 2)
+
+    def test_flag_function(self) -> None:
+        """Test lz flagging."""
+        data = [
+            [1, 1, 1, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 1, 1, 1],
+        ]
+        scores, flags = lz_flag(data, threshold=-1.5)
+        self.assertEqual(len(flags), 2)
+        self.assertTrue(flags.dtype == bool)
+
+    def test_flag_with_custom_threshold(self) -> None:
+        """Test lz flagging with custom threshold."""
+        data = [[1, 1, 0, 0], [1, 0, 1, 0]]
+        scores, flags = lz_flag(data, threshold=0.0)
+        self.assertEqual(len(flags), 2)
+
+    def test_with_nan(self) -> None:
+        """Test handling of missing values."""
+        data = [[1, 1, np.nan, 0], [1, 0, 1, 0]]
+        result = lz(data, na_rm=True)
+        self.assertEqual(len(result), 2)
+
+    def test_all_correct_responses(self) -> None:
+        """Test handling of all correct responses."""
+        data = [[1, 1, 1, 1], [0, 0, 0, 0]]
+        result = lz(data)
+        self.assertEqual(len(result), 2)
+        self.assertFalse(np.isnan(result[0]))
+
+    def test_polytomous_dichotomization(self) -> None:
+        """Test that polytomous data is dichotomized."""
+        data = [[5, 4, 3, 2, 1], [1, 2, 3, 4, 5]]
+        result = lz(data)
+        self.assertEqual(len(result), 2)
+
+    def test_invalid_model_raises(self) -> None:
+        """Test that invalid model raises ValueError."""
+        data = [[1, 1, 0, 0]]
+        with self.assertRaises(ValueError):
+            lz(data, model="invalid")
+
+    def test_mismatched_difficulty_raises(self) -> None:
+        """Test that mismatched difficulty length raises ValueError."""
+        data = [[1, 1, 0, 0]]
+        with self.assertRaises(ValueError):
+            lz(data, difficulty=[1.0, 2.0])
+
+    def test_mismatched_discrimination_raises(self) -> None:
+        """Test that mismatched discrimination length raises ValueError."""
+        data = [[1, 1, 0, 0]]
+        with self.assertRaises(ValueError):
+            lz(data, discrimination=[1.0, 2.0])
+
+    def test_mismatched_theta_raises(self) -> None:
+        """Test that mismatched theta length raises ValueError."""
+        data = [[1, 1, 0, 0], [0, 0, 1, 1]]
+        with self.assertRaises(ValueError):
+            lz(data, theta=[0.0])
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "insufficient-effort"
-version = "1.1.4"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
- Add MAD (Mean Absolute Difference) for detecting careless responding to reverse-coded items
- Add lz (Standardized Log-Likelihood) IRT-based person-fit statistic
- Add composite index combining multiple IER indices with configurable combination methods (mean, sum, max)
- Add comprehensive tests for all new functions
- Bump version to 1.3.0