### PR TITLE
feat: add MAD, lz, and composite IER detection indices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "insufficient-effort"
-version = "1.3.0"
+version = "1.4.0"
 authors = [{ name = "Cameron Lyons", email = "cameron.lyons2@gmail.com" }]
 description = "Python library for detecting Insufficient Effort Responding (IER) in survey data"
 readme = "README.md"

--- a/tests/test_new_functions.py
+++ b/tests/test_new_functions.py
@@ -98,7 +98,10 @@ class TestGuttman(unittest.TestCase):
         data = [[1, 2, 3, 4, 5], [5, 4, 3, 2, 1]]
         flags = guttman_flag(data, threshold=0.3)
         self.assertEqual(len(flags), 2)
-        self.assertTrue(flags.dtype == bool)
+        self.assertTrue(
+            np.issubdtype(flags.dtype, np.bool_),
+            msg=f"Expected boolean dtype, got {flags.dtype}",
+        )
 
 
 class TestResponseTime(unittest.TestCase):
@@ -151,7 +154,10 @@ class TestIndividualReliability(unittest.TestCase):
         data = [[1, 2, 1, 2, 1, 2], [1, 5, 2, 4, 3, 3]]
         flags = individual_reliability_flag(data, n_splits=10, random_seed=42)
         self.assertEqual(len(flags), 2)
-        self.assertTrue(flags.dtype == bool)
+        self.assertTrue(
+            np.issubdtype(flags.dtype, np.bool_),
+            msg=f"Expected boolean dtype, got {flags.dtype}",
+        )
 
 
 class TestU3Poly(unittest.TestCase):
@@ -243,7 +249,10 @@ class TestComposite(unittest.TestCase):
         ]
         scores, flags = composite_flag(data, threshold=1.0)
         self.assertEqual(len(flags), 3)
-        self.assertTrue(flags.dtype == bool)
+        self.assertTrue(
+            np.issubdtype(flags.dtype, np.bool_),
+            msg=f"Expected boolean dtype, got {flags.dtype}",
+        )
         self.assertTrue(flags[1])
 
     def test_flag_with_percentile(self) -> None:
@@ -334,7 +343,10 @@ class TestMAD(unittest.TestCase):
             data, positive_items=[0, 2], negative_items=[1, 3], scale_max=5, threshold=3.0
         )
         self.assertEqual(len(flags), 3)
-        self.assertTrue(flags.dtype == bool)
+        self.assertTrue(
+            np.issubdtype(flags.dtype, np.bool_),
+            msg=f"Expected boolean dtype, got {flags.dtype}",
+        )
         self.assertTrue(flags[1])
         self.assertFalse(flags[0])
 


### PR DESCRIPTION
## Summary
- Add MAD (Mean Absolute Difference) for detecting careless responding to reverse-coded items
- Add lz (Standardized Log-Likelihood) IRT-based person-fit statistic
- Add composite index combining multiple IER indices with configurable combination methods (mean, sum, max)
- Add comprehensive tests for all new functions (39 new tests)
- Update README with documentation for new functions
- Bump version to 1.3.0

## New Functions
- `mad()` / `mad_flag()` - Mean Absolute Difference
- `lz()` / `lz_flag()` - Standardized Log-Likelihood
- `composite()` / `composite_flag()` / `composite_summary()` - Combined index

## Test plan
- [x] All 147 tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Ruff formatting passes