### PR TITLE
ci: skip version check for dependabot PRs

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -9,6 +9,7 @@ jobs:
   version-check:
     name: Check version updated
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "insufficient-effort"
-version = "1.4.0"
+version = "1.4.1"
 authors = [{ name = "Cameron Lyons", email = "cameron.lyons2@gmail.com" }]
 description = "Python library for detecting Insufficient Effort Responding (IER) in survey data"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "insufficient-effort"
-version = "1.3.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- Skips the version-check workflow for Dependabot PRs since dependency updates should not require a package version bump

This fixes PR #37 (and future Dependabot PRs) which are blocked by the version-check failing.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Verify PR #37 passes CI after this is merged