### PR TITLE
ci: allow skipped version-check in veto workflow

### DIFF
--- a/.github/workflows/veto.yml
+++ b/.github/workflows/veto.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ "${{ needs.ci.result }}" != "success" ]] || \
              [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.security.result }}" != "success" ]] || \
-             [[ "${{ needs.version-check.result }}" != "success" ]]; then
+             [[ "${{ needs.version-check.result }}" != "success" && "${{ needs.version-check.result }}" != "skipped" ]]; then
             echo "CI: ${{ needs.ci.result }}"
             echo "Lint: ${{ needs.lint.result }}"
             echo "Security: ${{ needs.security.result }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "insufficient-effort"
-version = "1.4.1"
+version = "1.4.2"
 authors = [{ name = "Cameron Lyons", email = "cameron.lyons2@gmail.com" }]
 description = "Python library for detecting Insufficient Effort Responding (IER) in survey data"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "insufficient-effort"
-version = "1.4.1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- Updates the Veto workflow to accept "skipped" as a valid result for version-check
- This is needed because version-check now skips for Dependabot PRs (from #38)

Fixes PR #37 which is blocked by the Veto check failing.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Verify PR #37 passes CI after this is merged