### PR TITLE
feat: add screening, acquiescence index, and visualizations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "insufficient-effort"
-version = "1.5.0"
+version = "1.6.0"
 authors = [{ name = "Cameron Lyons", email = "cameron.lyons2@gmail.com" }]
 description = "Python library for detecting Insufficient Effort Responding (IER) in survey data"
 readme = "README.md"

--- a/src/ier/__init__.py
+++ b/src/ier/__init__.py
@@ -1,6 +1,8 @@
 """IER: Python library for detecting Insufficient Effort Responding in survey data."""
 
 from ._validation import MatrixLike as MatrixLike
+from .acquiescence import acquiescence as acquiescence
+from .acquiescence import acquiescence_flag as acquiescence_flag
 from .composite import composite as composite
 from .composite import composite_flag as composite_flag
 from .composite import composite_probability as composite_probability
@@ -33,14 +35,20 @@ from .response_time import response_time as response_time
 from .response_time import response_time_consistency as response_time_consistency
 from .response_time import response_time_flag as response_time_flag
 from .response_time import response_time_mixture as response_time_mixture
+from .screen import screen as screen
 from .semantic import semantic_ant as semantic_ant
 from .semantic import semantic_syn as semantic_syn
 from .u3_poly import midpoint_responding as midpoint_responding
 from .u3_poly import response_pattern as response_pattern
 from .u3_poly import u3_poly as u3_poly
+from .visualize import plot_distributions as plot_distributions
+from .visualize import plot_flag_counts as plot_flag_counts
+from .visualize import plot_flagged_heatmap as plot_flagged_heatmap
 
 __all__ = [
     "MatrixLike",
+    "acquiescence",
+    "acquiescence_flag",
     "composite",
     "composite_flag",
     "composite_probability",
@@ -68,6 +76,9 @@ __all__ = [
     "onset",
     "onset_flag",
     "person_total",
+    "plot_distributions",
+    "plot_flag_counts",
+    "plot_flagged_heatmap",
     "psychant",
     "psychsyn",
     "response_pattern",
@@ -75,6 +86,7 @@ __all__ = [
     "response_time_consistency",
     "response_time_flag",
     "response_time_mixture",
+    "screen",
     "semantic_ant",
     "semantic_syn",
     "u3_poly",

--- a/src/ier/acquiescence.py
+++ b/src/ier/acquiescence.py
@@ -1,0 +1,162 @@
+"""
+Acquiescence index for detecting response bias in survey data.
+
+Acquiescence bias is the tendency for respondents to agree with items regardless
+of content. This module extends the basic mean-response measure in response_pattern()
+with scale normalization and balanced-pair mode for isolating pure acquiescence bias.
+
+References:
+- Paulhus, D. L. (1991). Measurement and control of response bias. In J. P. Robinson,
+  P. R. Shaver, & L. S. Wrightsman (Eds.), Measures of personality and social
+  psychological attitudes (pp. 17-59). Academic Press.
+"""
+
+import numpy as np
+
+from ier._validation import MatrixLike, validate_matrix_input
+
+
+def acquiescence(
+    x: MatrixLike,
+    scale_min: float | None = None,
+    scale_max: float | None = None,
+    positive_items: list[int] | None = None,
+    negative_items: list[int] | None = None,
+    na_rm: bool = True,
+) -> np.ndarray:
+    """
+    Calculate acquiescence index for each respondent.
+
+    In simple mode (no item lists), computes the normalized mean response per person
+    on a [0, 1] scale where 0.5 indicates no bias.
+
+    In balanced-pair mode (with positive/negative items), isolates pure acquiescence
+    bias by averaging (positive + reversed_negative) / 2 across pairs, then normalizing.
+
+    Parameters:
+    - x: A matrix of data where rows are individuals and columns are item responses.
+    - scale_min: Minimum value of the response scale. If None, inferred from data.
+    - scale_max: Maximum value of the response scale. If None, inferred from data.
+    - positive_items: List of column indices (0-based) for positively-worded items.
+    - negative_items: List of column indices (0-based) for negatively-worded items.
+    - na_rm: Boolean indicating whether to ignore missing values during computation.
+
+    Returns:
+    - A numpy array of acquiescence scores in [0, 1] for each individual.
+      Values near 0.5 indicate no acquiescence bias, values near 1.0 indicate
+      strong agreement bias.
+
+    Raises:
+    - ValueError: If inputs are invalid or item indices are out of bounds.
+
+    Example:
+        >>> data = [[5, 5, 5, 5], [1, 1, 1, 1], [3, 3, 3, 3]]
+        >>> scores = acquiescence(data, scale_min=1, scale_max=5)
+        >>> print(scores)
+        [1.0, 0.0, 0.5]
+    """
+    x_array = validate_matrix_input(x, check_type=False)
+
+    if scale_min is None:
+        scale_min = float(np.nanmin(x_array))
+    if scale_max is None:
+        scale_max = float(np.nanmax(x_array))
+
+    scale_range = scale_max - scale_min
+    if scale_range < 0:
+        raise ValueError("scale_max must be greater than scale_min")
+    if scale_range == 0:
+        return np.full(x_array.shape[0], 0.5)
+
+    has_positive = positive_items is not None
+    has_negative = negative_items is not None
+
+    if has_positive != has_negative:
+        raise ValueError("must specify both positive_items and negative_items, or neither")
+
+    if has_positive and has_negative:
+        assert positive_items is not None
+        assert negative_items is not None
+
+        if len(positive_items) == 0 or len(negative_items) == 0:
+            raise ValueError("positive_items and negative_items cannot be empty")
+
+        n_cols = x_array.shape[1]
+        for idx in positive_items + negative_items:
+            if idx < 0 or idx >= n_cols:
+                raise ValueError(f"item index {idx} out of bounds for data with {n_cols} columns")
+
+        min_len = min(len(positive_items), len(negative_items))
+        pos_responses = x_array[:, positive_items[:min_len]].astype(float)
+        neg_responses = x_array[:, negative_items[:min_len]].astype(float)
+
+        reversed_neg = (scale_max + scale_min) - neg_responses
+        pair_means = (pos_responses + reversed_neg) / 2.0
+
+        if na_rm:
+            raw_scores: np.ndarray = np.nanmean(pair_means, axis=1)
+        else:
+            raw_scores = np.mean(pair_means, axis=1)
+    else:
+        if na_rm:
+            raw_scores = np.nanmean(x_array.astype(float), axis=1)
+        else:
+            raw_scores = np.mean(x_array.astype(float), axis=1)
+
+    normalized: np.ndarray = np.clip((raw_scores - scale_min) / scale_range, 0.0, 1.0)
+    return normalized
+
+
+def acquiescence_flag(
+    x: MatrixLike,
+    scale_min: float | None = None,
+    scale_max: float | None = None,
+    positive_items: list[int] | None = None,
+    negative_items: list[int] | None = None,
+    threshold: float | None = None,
+    percentile: float = 95.0,
+    na_rm: bool = True,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Calculate acquiescence scores and flag potential biased responders.
+
+    Parameters:
+    - x: A matrix of data where rows are individuals and columns are item responses.
+    - scale_min: Minimum value of the response scale.
+    - scale_max: Maximum value of the response scale.
+    - positive_items: List of column indices for positively-worded items.
+    - negative_items: List of column indices for negatively-worded items.
+    - threshold: Absolute threshold above which to flag. If None, uses percentile.
+    - percentile: Percentile cutoff for flagging (default 95th percentile).
+    - na_rm: Boolean indicating whether to ignore missing values.
+
+    Returns:
+    - Tuple of (acquiescence_scores, flags) where flags is True for suspected
+      biased responders.
+
+    Example:
+        >>> data = [[5, 5, 5, 5], [3, 3, 3, 3], [1, 1, 1, 1]]
+        >>> scores, flags = acquiescence_flag(data, scale_min=1, scale_max=5)
+    """
+    scores = acquiescence(
+        x,
+        scale_min=scale_min,
+        scale_max=scale_max,
+        positive_items=positive_items,
+        negative_items=negative_items,
+        na_rm=na_rm,
+    )
+
+    valid_scores = scores[~np.isnan(scores)]
+
+    if threshold is None:
+        if len(valid_scores) == 0:
+            threshold = 0.0
+        else:
+            threshold = float(np.percentile(valid_scores, percentile))
+
+    flags = np.zeros(len(scores), dtype=bool)
+    valid_mask = ~np.isnan(scores)
+    flags[valid_mask] = scores[valid_mask] > threshold
+
+    return scores, flags

--- a/src/ier/screen.py
+++ b/src/ier/screen.py
@@ -1,0 +1,256 @@
+"""
+Screening function that runs multiple IER detection indices at once.
+
+Provides a single entry point for computing all available IER indices,
+flagging suspected careless responders, and summarizing results.
+"""
+
+import contextlib
+from typing import Any
+
+import numpy as np
+
+from ier._validation import MatrixLike, validate_matrix_input
+from ier.acquiescence import acquiescence
+from ier.evenodd import evenodd
+from ier.irv import irv
+from ier.longstring import longstring, longstring_pattern
+from ier.lz import lz
+from ier.mad import mad
+from ier.mahad import mahad
+from ier.markov import markov
+from ier.person_total import person_total
+from ier.psychsyn import psychsyn
+from ier.u3_poly import midpoint_responding, u3_poly
+
+_DEFAULT_INDICES = [
+    "irv",
+    "longstring",
+    "longstring_pattern",
+    "mahad",
+    "psychsyn",
+    "person_total",
+    "markov",
+    "u3_poly",
+    "midpoint",
+    "acquiescence",
+]
+
+_OPTIONAL_INDICES = ["evenodd", "mad", "lz"]
+
+_ALL_INDICES = _DEFAULT_INDICES + _OPTIONAL_INDICES
+
+_HIGH_IS_CARELESS = {
+    "longstring",
+    "longstring_pattern",
+    "mahad",
+    "u3_poly",
+    "midpoint",
+    "acquiescence",
+    "mad",
+}
+
+_LOW_IS_CARELESS = {
+    "irv",
+    "psychsyn",
+    "person_total",
+    "markov",
+    "evenodd",
+    "lz",
+}
+
+
+def screen(
+    x: MatrixLike,
+    indices: list[str] | None = None,
+    na_rm: bool = True,
+    percentile: float = 95.0,
+    psychsyn_critval: float = 0.6,
+    evenodd_factors: list[int] | None = None,
+    mad_positive_items: list[int] | None = None,
+    mad_negative_items: list[int] | None = None,
+    mad_scale_max: int | None = None,
+    scale_min: float | None = None,
+    scale_max: float | None = None,
+) -> dict[str, Any]:
+    """
+    Screen respondents across multiple IER detection indices.
+
+    Computes each requested index, flags outliers using percentile-based
+    thresholds, and returns structured results.
+
+    Parameters:
+    - x: A matrix of data where rows are individuals and columns are item responses.
+    - indices: List of indices to compute. If None, uses defaults (indices not
+              requiring extra config). Options: "irv", "longstring", "longstring_pattern",
+              "mahad", "psychsyn", "person_total", "markov", "u3_poly", "midpoint",
+              "acquiescence", "evenodd", "mad", "lz".
+    - na_rm: Handle missing values in individual indices.
+    - percentile: Percentile cutoff for flagging (default 95th).
+    - psychsyn_critval: Critical correlation value for psychometric synonyms.
+    - evenodd_factors: Factor lengths for even-odd consistency.
+    - mad_positive_items: Column indices for positively-worded items (for MAD).
+    - mad_negative_items: Column indices for negatively-worded items (for MAD).
+    - mad_scale_max: Maximum value of response scale (for MAD).
+    - scale_min: Minimum value of response scale (for u3_poly, midpoint, acquiescence).
+    - scale_max: Maximum value of response scale (for u3_poly, midpoint, acquiescence).
+
+    Returns:
+    - Dictionary with:
+        - "scores": dict mapping index name to score array
+        - "flags": dict mapping index name to boolean flag array
+        - "flag_counts": array of total flags per respondent
+        - "n_indices": number of indices successfully computed
+        - "indices_used": list of index names computed
+        - "n_respondents": number of respondents
+        - "summary": dict mapping index name to summary statistics
+
+    Raises:
+    - ValueError: If invalid index names are specified.
+
+    Example:
+        >>> data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3], [5, 4, 3, 2, 1]]
+        >>> result = screen(data)
+        >>> print(result["indices_used"])
+        >>> print(result["flag_counts"])
+    """
+    x_array = validate_matrix_input(x, check_type=False)
+    n_respondents = x_array.shape[0]
+
+    if indices is None:
+        indices = list(_DEFAULT_INDICES)
+    else:
+        for idx in indices:
+            if idx not in _ALL_INDICES:
+                raise ValueError(f"invalid index '{idx}'. Valid options: {sorted(_ALL_INDICES)}")
+
+    scores: dict[str, np.ndarray] = {}
+
+    if "irv" in indices:
+        with contextlib.suppress(ValueError):
+            scores["irv"] = irv(x_array, na_rm=na_rm)
+
+    if "longstring" in indices:
+        with contextlib.suppress(ValueError):
+            response_strings = [
+                "".join(str(int(v)) if not np.isnan(v) else "" for v in row) for row in x_array
+            ]
+            ls_results = longstring(response_strings)
+            scores["longstring"] = np.array(
+                [r[1] if r is not None else 0 for r in ls_results], dtype=float
+            )
+
+    if "longstring_pattern" in indices:
+        with contextlib.suppress(ValueError):
+            scores["longstring_pattern"] = longstring_pattern(x_array, na_rm=na_rm)
+
+    if "mahad" in indices:
+        with contextlib.suppress(ValueError):
+            mahad_result = mahad(x_array, na_rm=na_rm)
+            if isinstance(mahad_result, np.ndarray):
+                scores["mahad"] = mahad_result
+
+    if "psychsyn" in indices:
+        with contextlib.suppress(ValueError), np.errstate(divide="ignore", invalid="ignore"):
+            psyn_result = psychsyn(x_array, critval=psychsyn_critval, resample_na=na_rm)
+            if isinstance(psyn_result, np.ndarray):
+                scores["psychsyn"] = psyn_result
+
+    if "person_total" in indices:
+        with contextlib.suppress(ValueError):
+            scores["person_total"] = person_total(x_array, na_rm=na_rm)
+
+    if "markov" in indices:
+        with contextlib.suppress(ValueError):
+            scores["markov"] = markov(x_array, na_rm=na_rm)
+
+    if "u3_poly" in indices:
+        with contextlib.suppress(ValueError):
+            scores["u3_poly"] = u3_poly(x_array, scale_min=scale_min, scale_max=scale_max)
+
+    if "midpoint" in indices:
+        with contextlib.suppress(ValueError):
+            scores["midpoint"] = midpoint_responding(
+                x_array, scale_min=scale_min, scale_max=scale_max
+            )
+
+    if "acquiescence" in indices:
+        with contextlib.suppress(ValueError):
+            scores["acquiescence"] = acquiescence(
+                x_array, scale_min=scale_min, scale_max=scale_max, na_rm=na_rm
+            )
+
+    if "evenodd" in indices and evenodd_factors is not None:
+        with contextlib.suppress(ValueError):
+            eo_result = evenodd(x_array, factors=evenodd_factors)
+            if isinstance(eo_result, np.ndarray):
+                scores["evenodd"] = eo_result
+
+    if "mad" in indices and mad_positive_items is not None and mad_negative_items is not None:
+        with contextlib.suppress(ValueError):
+            scores["mad"] = mad(
+                x_array,
+                positive_items=mad_positive_items,
+                negative_items=mad_negative_items,
+                scale_max=mad_scale_max,
+                na_rm=na_rm,
+            )
+
+    if "lz" in indices:
+        with contextlib.suppress(ValueError):
+            scores["lz"] = lz(x_array, na_rm=na_rm)
+
+    flags: dict[str, np.ndarray] = {}
+    for name, score_arr in scores.items():
+        valid_scores = score_arr[~np.isnan(score_arr)]
+        if len(valid_scores) == 0:
+            flags[name] = np.zeros(n_respondents, dtype=bool)
+            continue
+
+        cutoff = float(np.percentile(valid_scores, percentile))
+
+        flag_arr = np.zeros(n_respondents, dtype=bool)
+        valid_mask = ~np.isnan(score_arr)
+
+        if name in _HIGH_IS_CARELESS:
+            flag_arr[valid_mask] = score_arr[valid_mask] > cutoff
+        else:
+            low_cutoff = float(np.percentile(valid_scores, 100.0 - percentile))
+            flag_arr[valid_mask] = score_arr[valid_mask] < low_cutoff
+
+        flags[name] = flag_arr
+
+    flag_matrix = (
+        np.column_stack(list(flags.values())) if flags else np.zeros((n_respondents, 0), dtype=bool)
+    )
+    flag_counts: np.ndarray = np.sum(flag_matrix, axis=1)
+
+    summary: dict[str, dict[str, float]] = {}
+    for name, score_arr in scores.items():
+        valid = score_arr[~np.isnan(score_arr)]
+        if len(valid) > 0:
+            summary[name] = {
+                "mean": float(np.mean(valid)),
+                "std": float(np.std(valid)),
+                "min": float(np.min(valid)),
+                "max": float(np.max(valid)),
+                "n_flagged": int(np.sum(flags[name])),
+            }
+        else:
+            summary[name] = {
+                "mean": float("nan"),
+                "std": float("nan"),
+                "min": float("nan"),
+                "max": float("nan"),
+                "n_flagged": 0,
+            }
+
+    return {
+        "scores": scores,
+        "flags": flags,
+        "flag_counts": flag_counts,
+        "n_indices": len(scores),
+        "indices_used": list(scores.keys()),
+        "n_respondents": n_respondents,
+        "summary": summary,
+    }

--- a/src/ier/visualize.py
+++ b/src/ier/visualize.py
@@ -1,0 +1,183 @@
+"""
+Visualization functions for IER screening results.
+
+Provides plots for inspecting the output of screen(), including
+score distributions, flag heatmaps, and flag count summaries.
+"""
+
+from typing import Any
+
+import numpy as np
+
+
+def plot_distributions(
+    screen_result: dict[str, Any],
+    figsize: tuple[float, float] | None = None,
+    bins: int = 30,
+) -> Any:
+    """
+    Plot histograms of score distributions for each index.
+
+    Parameters:
+    - screen_result: Output dict from screen().
+    - figsize: Figure size as (width, height). If None, auto-calculated.
+    - bins: Number of histogram bins.
+
+    Returns:
+    - matplotlib Figure object.
+
+    Raises:
+    - RuntimeError: If matplotlib is not available.
+
+    Example:
+        >>> result = screen(data)
+        >>> fig = plot_distributions(result)
+        >>> fig.savefig("distributions.png")
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise RuntimeError(
+            "matplotlib is required for plotting. "
+            "Install with: pip install insufficient-effort[plot]"
+        ) from exc
+
+    scores: dict[str, np.ndarray] = screen_result["scores"]
+    n_indices = len(scores)
+
+    if n_indices == 0:
+        fig, _ = plt.subplots(1, 1, figsize=figsize or (6, 4))
+        return fig
+
+    n_cols = min(3, n_indices)
+    n_rows = (n_indices + n_cols - 1) // n_cols
+
+    if figsize is None:
+        figsize = (4 * n_cols, 3 * n_rows)
+
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=figsize, squeeze=False)
+
+    for i, (name, score_arr) in enumerate(scores.items()):
+        row, col = divmod(i, n_cols)
+        ax = axes[row][col]
+        valid = score_arr[~np.isnan(score_arr)]
+        ax.hist(valid, bins=bins, edgecolor="black", alpha=0.7)
+        ax.set_title(name)
+        ax.set_xlabel("Score")
+        ax.set_ylabel("Count")
+
+    for i in range(n_indices, n_rows * n_cols):
+        row, col = divmod(i, n_cols)
+        axes[row][col].set_visible(False)
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_flagged_heatmap(
+    screen_result: dict[str, Any],
+    figsize: tuple[float, float] | None = None,
+    cmap: str = "Reds",
+) -> Any:
+    """
+    Plot a heatmap of flag status per respondent and index.
+
+    Rows are respondents, columns are indices. Colored cells indicate flagged.
+
+    Parameters:
+    - screen_result: Output dict from screen().
+    - figsize: Figure size as (width, height).
+    - cmap: Matplotlib colormap name.
+
+    Returns:
+    - matplotlib Figure object.
+
+    Raises:
+    - RuntimeError: If matplotlib is not available.
+
+    Example:
+        >>> result = screen(data)
+        >>> fig = plot_flagged_heatmap(result)
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise RuntimeError(
+            "matplotlib is required for plotting. "
+            "Install with: pip install insufficient-effort[plot]"
+        ) from exc
+
+    flags: dict[str, np.ndarray] = screen_result["flags"]
+    index_names = list(flags.keys())
+
+    if len(index_names) == 0:
+        fig, _ = plt.subplots(1, 1, figsize=figsize or (6, 4))
+        return fig
+
+    flag_matrix = np.column_stack([flags[name] for name in index_names]).astype(float)
+
+    if figsize is None:
+        figsize = (max(6, len(index_names) * 0.8), max(4, flag_matrix.shape[0] * 0.15))
+
+    fig, ax = plt.subplots(1, 1, figsize=figsize)
+    ax.imshow(flag_matrix, aspect="auto", cmap=cmap, interpolation="nearest")
+    ax.set_xticks(range(len(index_names)))
+    ax.set_xticklabels(index_names, rotation=45, ha="right")
+    ax.set_xlabel("Index")
+    ax.set_ylabel("Respondent")
+    ax.set_title("IER Flag Heatmap")
+    fig.tight_layout()
+    return fig
+
+
+def plot_flag_counts(
+    screen_result: dict[str, Any],
+    figsize: tuple[float, float] | None = None,
+) -> Any:
+    """
+    Plot a bar chart of flag counts across respondents.
+
+    X-axis is the number of flags, y-axis is the count of respondents
+    with that many flags.
+
+    Parameters:
+    - screen_result: Output dict from screen().
+    - figsize: Figure size as (width, height).
+
+    Returns:
+    - matplotlib Figure object.
+
+    Raises:
+    - RuntimeError: If matplotlib is not available.
+
+    Example:
+        >>> result = screen(data)
+        >>> fig = plot_flag_counts(result)
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise RuntimeError(
+            "matplotlib is required for plotting. "
+            "Install with: pip install insufficient-effort[plot]"
+        ) from exc
+
+    flag_counts: np.ndarray = screen_result["flag_counts"]
+    n_indices: int = screen_result["n_indices"]
+
+    if figsize is None:
+        figsize = (8, 5)
+
+    fig, ax = plt.subplots(1, 1, figsize=figsize)
+
+    max_flags = max(int(np.max(flag_counts)), 0) if len(flag_counts) > 0 else 0
+    bins_range = range(0, max(max_flags + 2, n_indices + 2))
+    counts_per_bin = [int(np.sum(flag_counts == b)) for b in bins_range]
+
+    ax.bar(list(bins_range), counts_per_bin, edgecolor="black", alpha=0.7)
+    ax.set_xlabel("Number of Flags")
+    ax.set_ylabel("Number of Respondents")
+    ax.set_title("Distribution of IER Flag Counts")
+    ax.set_xticks(list(bins_range))
+    fig.tight_layout()
+    return fig

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1,0 +1,297 @@
+"""Unit tests for acquiescence, screen, and visualization functions."""
+
+import unittest
+
+import numpy as np
+
+from ier.acquiescence import acquiescence, acquiescence_flag
+from ier.screen import screen
+from ier.visualize import plot_distributions, plot_flag_counts, plot_flagged_heatmap
+
+
+class TestAcquiescence(unittest.TestCase):
+    """Tests for acquiescence index."""
+
+    def test_simple_mode_all_agree(self) -> None:
+        data = [[5, 5, 5, 5], [5, 5, 5, 5]]
+        scores = acquiescence(data, scale_min=1, scale_max=5)
+        np.testing.assert_array_almost_equal(scores, [1.0, 1.0])
+
+    def test_simple_mode_all_disagree(self) -> None:
+        data = [[1, 1, 1, 1], [1, 1, 1, 1]]
+        scores = acquiescence(data, scale_min=1, scale_max=5)
+        np.testing.assert_array_almost_equal(scores, [0.0, 0.0])
+
+    def test_simple_mode_midpoint(self) -> None:
+        data = [[3, 3, 3, 3]]
+        scores = acquiescence(data, scale_min=1, scale_max=5)
+        np.testing.assert_array_almost_equal(scores, [0.5])
+
+    def test_simple_mode_range(self) -> None:
+        data = [[1, 2, 3, 4, 5], [5, 4, 3, 2, 1]]
+        scores = acquiescence(data, scale_min=1, scale_max=5)
+        np.testing.assert_array_almost_equal(scores, [0.5, 0.5])
+
+    def test_balanced_pair_mode(self) -> None:
+        data = [[5, 1, 4, 2], [3, 3, 3, 3]]
+        scores = acquiescence(
+            data, scale_min=1, scale_max=5, positive_items=[0, 2], negative_items=[1, 3]
+        )
+        self.assertEqual(len(scores), 2)
+        self.assertTrue(np.all(scores >= 0))
+        self.assertTrue(np.all(scores <= 1))
+
+    def test_balanced_pair_acquiescent(self) -> None:
+        data = [[5, 4, 5, 4]]
+        scores = acquiescence(
+            data, scale_min=1, scale_max=5, positive_items=[0, 2], negative_items=[1, 3]
+        )
+        self.assertGreater(scores[0], 0.5)
+
+    def test_scale_inference(self) -> None:
+        data = [[1, 2, 3, 4, 5]]
+        scores = acquiescence(data)
+        self.assertEqual(len(scores), 1)
+        self.assertAlmostEqual(scores[0], 0.5)
+
+    def test_nan_handling(self) -> None:
+        data = [[1, np.nan, 3, 4, 5], [1, 2, 3, 4, 5]]
+        scores = acquiescence(data, scale_min=1, scale_max=5, na_rm=True)
+        self.assertEqual(len(scores), 2)
+        self.assertFalse(np.isnan(scores[0]))
+
+    def test_only_positive_items_raises(self) -> None:
+        data = [[1, 2, 3]]
+        with self.assertRaises(ValueError):
+            acquiescence(data, positive_items=[0])
+
+    def test_empty_items_raises(self) -> None:
+        data = [[1, 2, 3]]
+        with self.assertRaises(ValueError):
+            acquiescence(data, positive_items=[], negative_items=[])
+
+    def test_out_of_bounds_index_raises(self) -> None:
+        data = [[1, 2, 3]]
+        with self.assertRaises(ValueError):
+            acquiescence(data, positive_items=[0], negative_items=[10])
+
+    def test_equal_scale_returns_half(self) -> None:
+        data = [[3, 3, 3]]
+        scores = acquiescence(data, scale_min=3, scale_max=3)
+        self.assertAlmostEqual(scores[0], 0.5)
+
+    def test_inverted_scale_raises(self) -> None:
+        data = [[3, 3, 3]]
+        with self.assertRaises(ValueError):
+            acquiescence(data, scale_min=5, scale_max=1)
+
+
+class TestAcquiescenceFlag(unittest.TestCase):
+    """Tests for acquiescence_flag function."""
+
+    def test_returns_tuple(self) -> None:
+        data = [[5, 5, 5, 5], [3, 3, 3, 3], [1, 1, 1, 1]]
+        scores, flags = acquiescence_flag(data, scale_min=1, scale_max=5)
+        self.assertEqual(len(scores), 3)
+        self.assertEqual(len(flags), 3)
+        self.assertEqual(flags.dtype, bool)
+
+    def test_threshold_override(self) -> None:
+        data = [[5, 5, 5, 5], [3, 3, 3, 3], [1, 1, 1, 1]]
+        scores, flags = acquiescence_flag(data, scale_min=1, scale_max=5, threshold=0.9)
+        self.assertTrue(flags[0])
+        self.assertFalse(flags[1])
+        self.assertFalse(flags[2])
+
+
+class TestScreen(unittest.TestCase):
+    """Tests for screen function."""
+
+    def setUp(self) -> None:
+        rng = np.random.default_rng(42)
+        self.data = rng.integers(1, 6, size=(30, 10)).astype(float)
+        self.data[0, :] = 3.0
+
+    def test_basic_output_structure(self) -> None:
+        result = screen(self.data)
+        self.assertIn("scores", result)
+        self.assertIn("flags", result)
+        self.assertIn("flag_counts", result)
+        self.assertIn("n_indices", result)
+        self.assertIn("indices_used", result)
+        self.assertIn("n_respondents", result)
+        self.assertIn("summary", result)
+        self.assertEqual(result["n_respondents"], 30)
+
+    def test_scores_and_flags_same_keys(self) -> None:
+        result = screen(self.data)
+        self.assertEqual(set(result["scores"].keys()), set(result["flags"].keys()))
+
+    def test_flag_counts_bounded(self) -> None:
+        result = screen(self.data)
+        self.assertTrue(np.all(result["flag_counts"] >= 0))
+        self.assertTrue(np.all(result["flag_counts"] <= result["n_indices"]))
+
+    def test_flag_counts_length(self) -> None:
+        result = screen(self.data)
+        self.assertEqual(len(result["flag_counts"]), 30)
+
+    def test_straightliner_flagged(self) -> None:
+        result = screen(self.data)
+        self.assertGreater(result["flag_counts"][0], 0)
+
+    def test_specific_indices(self) -> None:
+        result = screen(self.data, indices=["irv", "longstring"])
+        self.assertEqual(set(result["indices_used"]), {"irv", "longstring"})
+
+    def test_invalid_index_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            screen(self.data, indices=["nonexistent"])
+
+    def test_evenodd_included_with_factors(self) -> None:
+        result = screen(self.data, indices=["evenodd"], evenodd_factors=[5, 5])
+        self.assertIn("evenodd", result["indices_used"])
+
+    def test_mad_included_with_items(self) -> None:
+        result = screen(
+            self.data,
+            indices=["mad"],
+            mad_positive_items=[0, 1, 2],
+            mad_negative_items=[3, 4, 5],
+        )
+        self.assertIn("mad", result["indices_used"])
+
+    def test_summary_stats(self) -> None:
+        result = screen(self.data, indices=["irv"])
+        self.assertIn("irv", result["summary"])
+        stats = result["summary"]["irv"]
+        self.assertIn("mean", stats)
+        self.assertIn("std", stats)
+        self.assertIn("min", stats)
+        self.assertIn("max", stats)
+        self.assertIn("n_flagged", stats)
+
+    def test_all_score_lengths_match(self) -> None:
+        result = screen(self.data)
+        for name, scores in result["scores"].items():
+            self.assertEqual(len(scores), 30, f"score length mismatch for {name}")
+
+    def test_all_flag_lengths_match(self) -> None:
+        result = screen(self.data)
+        for name, flags in result["flags"].items():
+            self.assertEqual(len(flags), 30, f"flag length mismatch for {name}")
+
+
+class TestPlotDistributions(unittest.TestCase):
+    """Tests for plot_distributions."""
+
+    def setUp(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        rng = np.random.default_rng(42)
+        self.data = rng.integers(1, 6, size=(20, 8)).astype(float)
+        self.result = screen(self.data, indices=["irv", "longstring"])
+
+    def test_returns_figure(self) -> None:
+        import matplotlib.pyplot as plt
+
+        fig = plot_distributions(self.result)
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_correct_subplot_count(self) -> None:
+        import matplotlib.pyplot as plt
+
+        fig = plot_distributions(self.result)
+        visible_axes = [ax for ax in fig.get_axes() if ax.get_visible()]
+        self.assertEqual(len(visible_axes), 2)
+        plt.close(fig)
+
+    def test_custom_figsize(self) -> None:
+        import matplotlib.pyplot as plt
+
+        fig = plot_distributions(self.result, figsize=(10, 5))
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_empty_scores(self) -> None:
+        import matplotlib.pyplot as plt
+
+        empty_result = {
+            "scores": {},
+            "flags": {},
+            "flag_counts": np.array([]),
+            "n_indices": 0,
+            "indices_used": [],
+            "n_respondents": 0,
+            "summary": {},
+        }
+        fig = plot_distributions(empty_result)
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+class TestPlotFlaggedHeatmap(unittest.TestCase):
+    """Tests for plot_flagged_heatmap."""
+
+    def setUp(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        rng = np.random.default_rng(42)
+        self.data = rng.integers(1, 6, size=(20, 8)).astype(float)
+        self.result = screen(self.data, indices=["irv", "longstring"])
+
+    def test_returns_figure(self) -> None:
+        import matplotlib.pyplot as plt
+
+        fig = plot_flagged_heatmap(self.result)
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_empty_flags(self) -> None:
+        import matplotlib.pyplot as plt
+
+        empty_result = {
+            "scores": {},
+            "flags": {},
+            "flag_counts": np.array([]),
+            "n_indices": 0,
+            "indices_used": [],
+            "n_respondents": 0,
+            "summary": {},
+        }
+        fig = plot_flagged_heatmap(empty_result)
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+class TestPlotFlagCounts(unittest.TestCase):
+    """Tests for plot_flag_counts."""
+
+    def setUp(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        rng = np.random.default_rng(42)
+        self.data = rng.integers(1, 6, size=(20, 8)).astype(float)
+        self.result = screen(self.data, indices=["irv", "longstring"])
+
+    def test_returns_figure(self) -> None:
+        import matplotlib.pyplot as plt
+
+        fig = plot_flag_counts(self.result)
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_custom_figsize(self) -> None:
+        import matplotlib.pyplot as plt
+
+        fig = plot_flag_counts(self.result, figsize=(12, 6))
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `acquiescence()` and `acquiescence_flag()` for detecting response bias (simple and balanced-pair modes, normalized [0, 1])
- Add `screen()` function that runs all IER indices at once and returns structured results (scores, flags, flag counts, summary stats)
- Add `plot_distributions()`, `plot_flagged_heatmap()`, and `plot_flag_counts()` visualization functions
- Add 36 unit tests and 3 property-based tests (241/241 pass, mypy clean)

## Test plan
- [x] All 241 tests pass
- [x] mypy --strict clean on all 23 source files
- [x] ruff format and ruff check clean