### PR TITLE
refactor: dedupe internal helper logic

### DIFF
--- a/src/ier/_flagging.py
+++ b/src/ier/_flagging.py
@@ -1,0 +1,31 @@
+"""Shared helpers for percentile/threshold-based flagging."""
+
+from typing import Literal
+
+import numpy as np
+
+
+def threshold_flags(
+    scores: np.ndarray,
+    threshold: float | None,
+    percentile: float,
+    direction: Literal["high", "low"],
+    inclusive: bool = False,
+) -> np.ndarray:
+    """Create boolean flags from scores using explicit or percentile thresholding."""
+    valid_scores = scores[~np.isnan(scores)]
+
+    cutoff = threshold
+    if cutoff is None:
+        cutoff = 0.0 if len(valid_scores) == 0 else float(np.percentile(valid_scores, percentile))
+
+    flags = np.zeros(len(scores), dtype=bool)
+    valid_mask = ~np.isnan(scores)
+    valid_values = scores[valid_mask]
+
+    if direction == "high":
+        flags[valid_mask] = valid_values >= cutoff if inclusive else valid_values > cutoff
+    else:
+        flags[valid_mask] = valid_values <= cutoff if inclusive else valid_values < cutoff
+
+    return flags

--- a/src/ier/_optional_imports.py
+++ b/src/ier/_optional_imports.py
@@ -1,0 +1,16 @@
+"""Helpers for optional runtime dependencies."""
+
+from typing import Any
+
+
+def require_matplotlib_pyplot() -> Any:
+    """Import matplotlib.pyplot or raise a clear optional-dependency error."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise RuntimeError(
+            "matplotlib is required for plotting. "
+            "Install with: pip install insufficient-effort[plot]"
+        ) from exc
+
+    return plt

--- a/src/ier/_validation.py
+++ b/src/ier/_validation.py
@@ -1,6 +1,6 @@
 """Shared input validation utilities for careless detection functions."""
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Any, Protocol, TypeAlias
 
 import numpy as np
@@ -14,6 +14,12 @@ class SupportsArray(Protocol):
 
 
 MatrixLike: TypeAlias = Sequence[Sequence[float | int]] | np.ndarray | SupportsArray | ArrayLike
+
+
+def iter_rows(x_array: np.ndarray, na_rm: bool) -> Iterator[np.ndarray]:
+    """Yield rows with optional NaN removal for repeated row-wise index routines."""
+    for row in x_array:
+        yield row[~np.isnan(row)] if na_rm else row
 
 
 def validate_matrix_input(

--- a/src/ier/acquiescence.py
+++ b/src/ier/acquiescence.py
@@ -13,6 +13,7 @@ References:
 
 import numpy as np
 
+from ier._flagging import threshold_flags
 from ier._validation import MatrixLike, validate_matrix_input
 
 
@@ -147,16 +148,6 @@ def acquiescence_flag(
         na_rm=na_rm,
     )
 
-    valid_scores = scores[~np.isnan(scores)]
-
-    if threshold is None:
-        if len(valid_scores) == 0:
-            threshold = 0.0
-        else:
-            threshold = float(np.percentile(valid_scores, percentile))
-
-    flags = np.zeros(len(scores), dtype=bool)
-    valid_mask = ~np.isnan(scores)
-    flags[valid_mask] = scores[valid_mask] > threshold
+    flags = threshold_flags(scores, threshold=threshold, percentile=percentile, direction="high")
 
     return scores, flags

--- a/src/ier/composite.py
+++ b/src/ier/composite.py
@@ -16,12 +16,13 @@ from typing import Any, Literal
 
 import numpy as np
 
+from ier._flagging import threshold_flags
 from ier._validation import MatrixLike, validate_matrix_input
 from ier.evenodd import evenodd
 from ier.irv import irv
 from ier.longstring import longstring_pattern, longstring_scores
 from ier.lz import lz
-from ier.mad import mad
+from ier.mad import add_mad_index_result
 from ier.mahad import mahad
 from ier.markov import markov
 from ier.person_total import person_total
@@ -30,6 +31,26 @@ from ier.psychsyn import psychsyn
 
 def _add_error(errors: dict[str, str], index_name: str, error: Exception) -> None:
     errors[index_name] = str(error)
+
+
+def _add_mad_score(
+    scores: dict[str, np.ndarray],
+    errors: dict[str, str],
+    x: np.ndarray,
+    positive_items: list[int] | None,
+    negative_items: list[int] | None,
+    scale_max: int | None,
+    na_rm: bool,
+) -> None:
+    add_mad_index_result(
+        scores=scores,
+        errors=errors,
+        x=x,
+        positive_items=positive_items,
+        negative_items=negative_items,
+        scale_max=scale_max,
+        na_rm=na_rm,
+    )
 
 
 def composite(
@@ -182,21 +203,15 @@ def composite(
             _add_error(diagnostics, "lz", err)
 
     if "mad" in indices:
-        if mad_positive_items is None or mad_negative_items is None:
-            diagnostics["mad"] = (
-                "mad_positive_items and mad_negative_items must be provided when using mad index"
-            )
-        else:
-            try:
-                index_scores["mad"] = mad(
-                    x_array,
-                    positive_items=mad_positive_items,
-                    negative_items=mad_negative_items,
-                    scale_max=mad_scale_max,
-                    na_rm=na_rm,
-                )
-            except ValueError as err:
-                _add_error(diagnostics, "mad", err)
+        _add_mad_score(
+            scores=index_scores,
+            errors=diagnostics,
+            x=x_array,
+            positive_items=mad_positive_items,
+            negative_items=mad_negative_items,
+            scale_max=mad_scale_max,
+            na_rm=na_rm,
+        )
 
     if "markov" in indices:
         try:
@@ -302,17 +317,7 @@ def composite_flag(
         scores = composite_result
         assert isinstance(scores, np.ndarray)
 
-    valid_scores = scores[~np.isnan(scores)]
-
-    if threshold is None:
-        if len(valid_scores) == 0:
-            threshold = 0.0
-        else:
-            threshold = float(np.percentile(valid_scores, percentile))
-
-    flags = np.zeros(len(scores), dtype=bool)
-    valid_mask = ~np.isnan(scores)
-    flags[valid_mask] = scores[valid_mask] > threshold
+    flags = threshold_flags(scores, threshold=threshold, percentile=percentile, direction="high")
 
     if return_diagnostics:
         return scores, flags, diagnostics
@@ -427,20 +432,15 @@ def composite_summary(
         except ValueError as err:
             _add_error(diagnostics, "lz", err)
 
-    if "mad" in indices and mad_positive_items is not None and mad_negative_items is not None:
-        try:
-            individual_scores["mad"] = mad(
-                x_array,
-                positive_items=mad_positive_items,
-                negative_items=mad_negative_items,
-                scale_max=mad_scale_max,
-                na_rm=na_rm,
-            )
-        except ValueError as err:
-            _add_error(diagnostics, "mad", err)
-    elif "mad" in indices:
-        diagnostics["mad"] = (
-            "mad_positive_items and mad_negative_items must be provided when using mad index"
+    if "mad" in indices:
+        _add_mad_score(
+            scores=individual_scores,
+            errors=diagnostics,
+            x=x_array,
+            positive_items=mad_positive_items,
+            negative_items=mad_negative_items,
+            scale_max=mad_scale_max,
+            na_rm=na_rm,
         )
 
     if "markov" in indices:

--- a/src/ier/longstring.py
+++ b/src/ier/longstring.py
@@ -11,7 +11,7 @@ from typing import Literal, overload
 
 import numpy as np
 
-from ier._validation import MatrixLike, validate_matrix_input
+from ier._validation import MatrixLike, iter_rows, validate_matrix_input
 
 
 def run_length_encode(message: str) -> list[tuple[str, int]]:
@@ -253,11 +253,7 @@ def longstring_pattern(
     n_rows = x_array.shape[0]
     result = np.zeros(n_rows, dtype=float)
 
-    for i in range(n_rows):
-        row = x_array[i, :]
-        if na_rm:
-            row = row[~np.isnan(row)]
-
+    for i, row in enumerate(iter_rows(x_array, na_rm)):
         if len(row) < 4:
             continue
 

--- a/src/ier/lz.py
+++ b/src/ier/lz.py
@@ -92,7 +92,7 @@ def lz(
             if len(a) != x_array.shape[1]:
                 raise ValueError("discrimination length must match number of items")
         else:
-            a = _estimate_discrimination(x_binary, b, na_rm=na_rm)
+            a = _estimate_discrimination(x_binary, na_rm=na_rm)
     else:
         a = np.ones(x_array.shape[1])
 
@@ -173,7 +173,7 @@ def _estimate_difficulty(x: np.ndarray, na_rm: bool = True) -> np.ndarray:
     return b
 
 
-def _estimate_discrimination(x: np.ndarray, b: np.ndarray, na_rm: bool = True) -> np.ndarray:
+def _estimate_discrimination(x: np.ndarray, na_rm: bool = True) -> np.ndarray:
     """Estimate item discrimination using point-biserial correlation."""
     n_items = x.shape[1]
     a = np.ones(n_items)

--- a/src/ier/mad.py
+++ b/src/ier/mad.py
@@ -13,6 +13,7 @@ References:
 
 import numpy as np
 
+from ier._flagging import threshold_flags
 from ier._validation import MatrixLike, validate_matrix_input
 
 
@@ -100,6 +101,51 @@ def mad(
     return result
 
 
+def run_mad_index(
+    x: MatrixLike,
+    positive_items: list[int] | None,
+    negative_items: list[int] | None,
+    scale_max: int | None,
+    na_rm: bool,
+) -> np.ndarray:
+    """Compute MAD with shared validation for optional screen/composite configurations."""
+    if positive_items is None or negative_items is None:
+        raise ValueError(
+            "mad_positive_items and mad_negative_items must be provided when using mad index"
+        )
+
+    return mad(
+        x,
+        positive_items=positive_items,
+        negative_items=negative_items,
+        scale_max=scale_max,
+        na_rm=na_rm,
+    )
+
+
+def add_mad_index_result(
+    scores: dict[str, np.ndarray],
+    errors: dict[str, str],
+    x: MatrixLike,
+    positive_items: list[int] | None,
+    negative_items: list[int] | None,
+    scale_max: int | None,
+    na_rm: bool,
+    index_name: str = "mad",
+) -> None:
+    """Populate score/error containers for MAD in orchestration-style APIs."""
+    try:
+        scores[index_name] = run_mad_index(
+            x,
+            positive_items=positive_items,
+            negative_items=negative_items,
+            scale_max=scale_max,
+            na_rm=na_rm,
+        )
+    except ValueError as err:
+        errors[index_name] = str(err)
+
+
 def mad_flag(
     x: MatrixLike,
     positive_items: list[int] | None = None,
@@ -143,16 +189,6 @@ def mad_flag(
         na_rm=na_rm,
     )
 
-    valid_scores = scores[~np.isnan(scores)]
-
-    if threshold is None:
-        if len(valid_scores) == 0:
-            threshold = 0.0
-        else:
-            threshold = float(np.percentile(valid_scores, percentile))
-
-    flags = np.zeros(len(scores), dtype=bool)
-    valid_mask = ~np.isnan(scores)
-    flags[valid_mask] = scores[valid_mask] > threshold
+    flags = threshold_flags(scores, threshold=threshold, percentile=percentile, direction="high")
 
     return scores, flags

--- a/src/ier/mahad.py
+++ b/src/ier/mahad.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import numpy as np
 
+from ier._optional_imports import require_matplotlib_pyplot
 from ier._summary import calculate_summary_stats
 from ier._validation import MatrixLike, validate_matrix_input
 
@@ -265,13 +266,7 @@ def mahad_qqplot(
     theoretical: np.ndarray = stats.chi2.ppf(probabilities, df=p)
 
     if plot:
-        try:
-            import matplotlib.pyplot as plt
-        except ImportError as exc:
-            raise RuntimeError(
-                "matplotlib is required for plotting. "
-                "Install with: pip install insufficient-effort[plot]"
-            ) from exc
+        plt = require_matplotlib_pyplot()
 
         _fig, ax = plt.subplots(1, 1)
         ax.scatter(theoretical, observed_sq, edgecolors="black", facecolors="none")

--- a/src/ier/markov.py
+++ b/src/ier/markov.py
@@ -15,8 +15,9 @@ from typing import Any
 
 import numpy as np
 
+from ier._flagging import threshold_flags
 from ier._summary import calculate_summary_stats
-from ier._validation import MatrixLike, validate_matrix_input
+from ier._validation import MatrixLike, iter_rows, validate_matrix_input
 
 
 def markov(
@@ -62,10 +63,7 @@ def markov(
     n_rows = x_array.shape[0]
     result = np.zeros(n_rows, dtype=float)
 
-    for i in range(n_rows):
-        row = x_array[i, :]
-        if na_rm:
-            row = row[~np.isnan(row)]
+    for i, row in enumerate(iter_rows(x_array, na_rm)):
         if len(row) < 2:
             result[i] = np.nan
             continue
@@ -100,17 +98,9 @@ def markov_flag(
     """
     scores = markov(x, na_rm=na_rm)
 
-    valid_scores = scores[~np.isnan(scores)]
-
-    if threshold is None:
-        if len(valid_scores) == 0:
-            threshold = 0.0
-        else:
-            threshold = float(np.percentile(valid_scores, percentile))
-
-    flags = np.zeros(len(scores), dtype=bool)
-    valid_mask = ~np.isnan(scores)
-    flags[valid_mask] = scores[valid_mask] <= threshold
+    flags = threshold_flags(
+        scores, threshold=threshold, percentile=percentile, direction="low", inclusive=True
+    )
 
     return scores, flags
 

--- a/src/ier/markov.py
+++ b/src/ier/markov.py
@@ -57,18 +57,28 @@ def markov(
         return np.full(x_array.shape[0], np.nan)
 
     categories = np.sort(np.unique(all_valid))
-    cat_map = {v: i for i, v in enumerate(categories)}
     k = len(categories)
 
     n_rows = x_array.shape[0]
-    result = np.zeros(n_rows, dtype=float)
+    if not na_rm:
+        encoded = np.searchsorted(categories, x_array)
+        from_ids = encoded[:, :-1]
+        to_ids = encoded[:, 1:]
+        n_transitions = from_ids.shape[1]
 
-    for i, row in enumerate(iter_rows(x_array, na_rm)):
+        transitions = np.zeros((n_rows, k, k), dtype=float)
+        row_ids = np.repeat(np.arange(n_rows), n_transitions)
+        np.add.at(transitions, (row_ids, from_ids.ravel(), to_ids.ravel()), 1.0)
+        return _transition_entropy_batch(transitions)
+
+    result = np.zeros(n_rows, dtype=float)
+    for i, row in enumerate(iter_rows(x_array, na_rm=True)):
         if len(row) < 2:
             result[i] = np.nan
             continue
 
-        trans = _build_transition_matrix(row, cat_map, k)
+        encoded_row = np.searchsorted(categories, row)
+        trans = _build_transition_matrix(encoded_row, k)
         result[i] = _transition_entropy(trans)
 
     return result
@@ -136,32 +146,56 @@ def markov_summary(
     return summary
 
 
-def _build_transition_matrix(row: np.ndarray, cat_map: dict[float, int], k: int) -> np.ndarray:
-    """Build a first-order transition count matrix from a response sequence."""
-    trans = np.zeros((k, k), dtype=float)
-    for t in range(len(row) - 1):
-        from_idx = cat_map[row[t]]
-        to_idx = cat_map[row[t + 1]]
-        trans[from_idx, to_idx] += 1
-    return trans
+def _build_transition_matrix(encoded_row: np.ndarray, k: int) -> np.ndarray:
+    """Build a first-order transition count matrix from integer-encoded responses."""
+    pair_ids = encoded_row[:-1] * k + encoded_row[1:]
+    counts = np.bincount(pair_ids, minlength=k * k).astype(float, copy=False)
+    return counts.reshape(k, k)
 
 
 def _transition_entropy(trans: np.ndarray) -> float:
-    """Compute Shannon entropy of transition matrix, weighted by row marginals."""
+    """Compute Shannon entropy of one transition matrix, weighted by row marginals."""
     row_sums = trans.sum(axis=1)
-    total = row_sums.sum()
+    total = float(row_sums.sum())
 
     if total == 0:
         return 0.0
 
-    entropy = 0.0
-    for i in range(trans.shape[0]):
-        if row_sums[i] == 0:
-            continue
-        probs = trans[i, :] / row_sums[i]
-        weight = row_sums[i] / total
-        for p in probs:
-            if p > 0:
-                entropy -= weight * p * np.log2(p)
+    probs = np.divide(
+        trans, row_sums[:, np.newaxis], out=np.zeros_like(trans), where=row_sums[:, np.newaxis] != 0
+    )
 
+    with np.errstate(divide="ignore", invalid="ignore"):
+        log_probs = np.log2(probs, where=probs > 0, out=np.zeros_like(probs))
+
+    entropy_terms = probs * log_probs
+    weights = row_sums / total
+    entropy = -np.sum(weights[:, np.newaxis] * entropy_terms)
     return float(entropy)
+
+
+def _transition_entropy_batch(transitions: np.ndarray) -> np.ndarray:
+    """Vectorized Shannon entropy for a batch of transition matrices."""
+    row_sums = transitions.sum(axis=2)
+    totals = row_sums.sum(axis=1)
+
+    probs = np.divide(
+        transitions,
+        row_sums[:, :, np.newaxis],
+        out=np.zeros_like(transitions),
+        where=row_sums[:, :, np.newaxis] != 0,
+    )
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        log_probs = np.log2(probs, where=probs > 0, out=np.zeros_like(probs))
+
+    entropy_terms = probs * log_probs
+    weights = np.divide(
+        row_sums,
+        totals[:, np.newaxis],
+        out=np.zeros_like(row_sums),
+        where=totals[:, np.newaxis] != 0,
+    )
+
+    result: np.ndarray = -np.sum(weights[:, :, np.newaxis] * entropy_terms, axis=(1, 2))
+    return result

--- a/src/ier/screen.py
+++ b/src/ier/screen.py
@@ -15,7 +15,7 @@ from ier.evenodd import evenodd
 from ier.irv import irv
 from ier.longstring import longstring_pattern, longstring_scores
 from ier.lz import lz
-from ier.mad import mad
+from ier.mad import add_mad_index_result
 from ier.mahad import mahad
 from ier.markov import markov
 from ier.person_total import person_total
@@ -150,22 +150,15 @@ def screen(
             continue
 
         if idx == "mad":
-            if mad_positive_items is None or mad_negative_items is None:
-                errors["mad"] = (
-                    "mad_positive_items and mad_negative_items must be provided "
-                    "when using mad index"
-                )
-                continue
-            try:
-                scores["mad"] = mad(
-                    x_array,
-                    positive_items=mad_positive_items,
-                    negative_items=mad_negative_items,
-                    scale_max=mad_scale_max,
-                    na_rm=na_rm,
-                )
-            except ValueError as err:
-                errors["mad"] = str(err)
+            add_mad_index_result(
+                scores,
+                errors,
+                x_array,
+                mad_positive_items,
+                mad_negative_items,
+                mad_scale_max,
+                na_rm,
+            )
             continue
 
         handler = index_handlers.get(idx)

--- a/src/ier/visualize.py
+++ b/src/ier/visualize.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import numpy as np
 
+from ier._optional_imports import require_matplotlib_pyplot
+
 
 def plot_distributions(
     screen_result: dict[str, Any],
@@ -34,13 +36,7 @@ def plot_distributions(
         >>> fig = plot_distributions(result)
         >>> fig.savefig("distributions.png")
     """
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError as exc:
-        raise RuntimeError(
-            "matplotlib is required for plotting. "
-            "Install with: pip install insufficient-effort[plot]"
-        ) from exc
+    plt = require_matplotlib_pyplot()
 
     scores: dict[str, np.ndarray] = screen_result["scores"]
     n_indices = len(scores)
@@ -99,13 +95,7 @@ def plot_flagged_heatmap(
         >>> result = screen(data)
         >>> fig = plot_flagged_heatmap(result)
     """
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError as exc:
-        raise RuntimeError(
-            "matplotlib is required for plotting. "
-            "Install with: pip install insufficient-effort[plot]"
-        ) from exc
+    plt = require_matplotlib_pyplot()
 
     flags: dict[str, np.ndarray] = screen_result["flags"]
     index_names = list(flags.keys())
@@ -154,13 +144,7 @@ def plot_flag_counts(
         >>> result = screen(data)
         >>> fig = plot_flag_counts(result)
     """
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError as exc:
-        raise RuntimeError(
-            "matplotlib is required for plotting. "
-            "Install with: pip install insufficient-effort[plot]"
-        ) from exc
+    plt = require_matplotlib_pyplot()
 
     flag_counts: np.ndarray = screen_result["flag_counts"]
     n_indices: int = screen_result["n_indices"]


### PR DESCRIPTION
## Summary\n- add shared helpers for threshold-based flagging and optional matplotlib imports\n- deduplicate MAD orchestration across composite/screen\n- reuse shared row-iteration helper in markov and longstring\n- remove unused parameter from lz discrimination estimation\n\n## Validation\n- ruff check src tests\n- mypy src/ier\n- pytest tests/ -q --cov=ier --cov-fail-under=82\n- pylint src/ier --disable=all --enable=R0801,W0612,W0613\n- vulture src/ier tests --min-confidence 80