### PR TITLE
Expand screen registry, harden defaults, and ship 1.7.0 docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
           files: ./coverage.xml
           # Tokenless uploads are rejected; keep CI green when CODECOV_TOKEN is unset.
           fail_ci_if_error: false
-          verbose: true  build:
+          verbose: true
+
+  build:
     name: Build distribution
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,16 @@ jobs:
         run: uv run pytest tests/ -v --cov=ier --cov-report=xml --cov-report=term-missing --cov-fail-under=90
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
+        if: >-
+          matrix.os == 'ubuntu-latest' &&
+          matrix.python-version == '3.14' &&
+          secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
-
   build:
     name: Build distribution
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,14 @@ jobs:
         run: uv run pytest tests/ -v --cov=ier --cov-report=xml --cov-report=term-missing --cov-fail-under=90
 
       - name: Upload coverage to Codecov
-        if: >-
-          matrix.os == 'ubuntu-latest' &&
-          matrix.python-version == '3.14' &&
-          secrets.CODECOV_TOKEN != ''
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-  build:
+          # Tokenless uploads are rejected; keep CI green when CODECOV_TOKEN is unset.
+          fail_ci_if_error: false
+          verbose: true  build:
     name: Build distribution
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: uv sync --locked --extra dev
 
       - name: Run tests with coverage
-        run: uv run pytest tests/ -v --cov=ier --cov-report=xml --cov-report=term-missing --cov-fail-under=82
+        run: uv run pytest tests/ -v --cov=ier --cov-report=xml --cov-report=term-missing --cov-fail-under=90
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
@@ -40,7 +40,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true
 
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Docs
+
+on:
+  workflow_call:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "src/ier/**"
+      - "CHANGELOG.md"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync --locked --extra docs
+
+      - name: Build docs
+        run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,4 +54,4 @@ jobs:
         run: uv sync --locked --extra dev
 
       - name: Run Bandit
-        run: uv run bandit -r src/ier -c pyproject.toml || uv run bandit -r src/ier -ll
+        run: uv run bandit -r src/ier -c pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.7.0] - 2026-07-23
+
+### Added
+
+- Registry coverage for `guttman`, `psychant`, `individual_reliability`, `onset`,
+  `semantic_syn`, `semantic_ant`, and `infrequency` in `screen()` / `composite()`.
+- `onset` presence-based flagging mode in `screen()`.
+- Expanded `screen()` / `composite()` configuration knobs for newly registered indices.
+- MkDocs documentation site (getting started, workflows, index catalog, thresholds,
+  R notes, API reference).
+- Benchmark script for the `screen()` hot path (`benchmarks/bench_screen.py`).
+- Example scripts under `examples/`.
+- pandas / polars smoke tests; pandas and polars added to the `dev` extra.
+- Curated changelog and expanded PyPI classifiers (Python 3.11–3.14).
+
+### Changed
+
+- Default `screen()` / `composite()` Mahalanobis scoring uses a NumPy-safe path
+  (`method="iqr"` distances). SciPy is only required for direct
+  `mahad(..., flag=True, method="chi2")` (and related SciPy-only helpers).
+- `score_registered_indices` soft-catches `ValueError`, `RuntimeError`, and
+  `TypeError` into per-index `errors`.
+- CI coverage gate aligned to 90%; Codecov upload fails the job on error;
+  Bandit no longer falls back to a looser severity filter.
+- Package version bumped to 1.7.0.
+
+### Fixed
+
+- Base-install footgun where default screening could abort on missing SciPy when
+  computing Mahalanobis distances with the previous chi-squared default path.
+
+## [1.6.3] - 2026-05
+
+### Changed
+
+- Dependency and CI maintenance releases (Dependabot, lockfile, Actions bumps).
+
+### Added
+
+- Index orchestration registry hardening and related workflow improvements.
+
+## Earlier
+
+Feature work through early 2026 introduced screening workflows, composite
+scoring, additional indices (including MAD, lz, acquiescence), visualizations,
+and multi-OS / multi-Python CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,19 @@ ruff check .
 ruff format --check .
 mypy src/ier
 pylint src/ier
+bandit -r src/ier -c pyproject.toml
+```
+
+Optional docs build:
+
+```bash
+uv run mkdocs build --strict
+```
+
+Optional screen benchmark:
+
+```bash
+uv run python benchmarks/bench_screen.py
 ```
 
 ## Pull Request Expectations

--- a/README.md
+++ b/README.md
@@ -1,49 +1,35 @@
 # IER
 
-A Python package for detecting Insufficient Effort Responding (IER) in survey data using various statistical indices and methods.
+Python package for detecting **Insufficient Effort Responding (IER)** / careless
+responding in survey data.
 
-## Overview
-
-When taking online surveys, participants sometimes respond to items without regard to their content. These types of responses, referred to as **insufficient effort responding** (IER) or **careless responding**, constitute significant problems for data quality, leading to distortions in data analysis and hypothesis testing.
-
-The `ier` package provides solutions designed to detect such insufficient effort responses by allowing easy calculation of indices proposed in the literature. For a comprehensive review of these methods, see [Curran (2016)](https://www.sciencedirect.com/science/article/abs/pii/S0022103115000931?via%3Dihub).
+For a comprehensive methods review, see
+[Curran (2016)](https://www.sciencedirect.com/science/article/abs/pii/S0022103115000931?via%3Dihub).
 
 ## Features
 
-- **Multiple Detection Methods**: Consistency, response-pattern, response-style, outlier, response-time, and attention-check indices
-- **Workflow APIs**: `screen()` runs multiple indices at once; `composite()` combines selected signals into a single score
-- **Flexible Input**: Works with lists, tuples, numpy arrays, and array-compatible DataFrame objects
-- **Robust Implementation**: Handles missing data and records per-index screening errors where possible
-- **Type Hints**: Full type annotations and typed result dictionaries for IDE support
+- Multiple detection families: consistency, response patterns, response styles, outliers, response times, attention checks
+- Workflow APIs: `screen()` and `composite()`
+- NumPy-first inputs (lists, arrays, array-compatible DataFrames)
+- Soft per-index errors during screening
+- Full type annotations (`py.typed`)
 
 ## Installation
 
-### From PyPI
 ```bash
 pip install insufficient-effort
 ```
 
-### From Source
-```bash
-git clone https://github.com/Cameron-Lyons/ier.git
-cd ier
-python -m pip install -e .
-```
-
-### Optional Dependencies
-Base installation includes NumPy-only indices. Install extras for SciPy-backed
-statistics and plotting:
+Optional extras:
 
 ```bash
-python -m pip install "insufficient-effort[full]"
-python -m pip install "insufficient-effort[plot]"
-python -m pip install "insufficient-effort[full,plot]"
+pip install "insufficient-effort[full]"   # SciPy helpers
+pip install "insufficient-effort[plot]"   # matplotlib visualizations
 ```
 
-The `full` extra is required for `mahad(method="chi2")`,
-`mahad_qqplot()`, and `response_time_mixture()`. The default `screen()` and
-`composite()` index sets include `mahad`, so install `full` or pass an
-explicit NumPy-only `indices=[...]` list.
+Base install is NumPy-only. Default `screen()` / `composite()` work without SciPy.
+SciPy is required for `mahad(..., flag=True, method="chi2")` and
+`response_time_mixture()`.
 
 ## Quick Start
 
@@ -51,476 +37,63 @@ explicit NumPy-only `indices=[...]` list.
 import numpy as np
 from ier import composite, irv, screen
 
-# Sample survey data (rows = participants, columns = items)
 data = np.array([
     [1, 2, 3, 4, 5, 4],
     [2, 3, 4, 3, 2, 1],
-    [3, 3, 3, 3, 3, 3],  # Straightlining
-    [1, 5, 1, 5, 1, 5],  # Alternating pattern
-    [5, 4, 3, 2, 1, 2],
-    [2, 2, 3, 4, 4, 5],
-    [4, 5, 4, 3, 2, 1],
-    [1, 2, 1, 2, 3, 4],
+    [3, 3, 3, 3, 3, 3],  # straightlining
+    [1, 5, 1, 5, 1, 5],  # alternating
 ], dtype=float)
 
-# Intra-individual response variability (low = straightlining)
 print("IRV:", irv(data))
 
-# Run a NumPy-only screening set
-indices = [
-    "irv",
-    "longstring",
-    "longstring_pattern",
-    "markov",
-    "person_total",
-    "u3_poly",
-    "midpoint",
-    "acquiescence",
-]
-result = screen(data, indices=indices, scale_min=1, scale_max=5)
-print("Indices used:", result["indices_used"])
+result = screen(data, scale_min=1, scale_max=5)
+print("Indices:", result["indices_used"])
 print("Flag counts:", result["flag_counts"])
 
-# Combine selected indices into one score
 scores = composite(data, indices=["irv", "longstring", "person_total", "markov"])
 print("Composite:", scores)
 ```
 
-## Available Functions
+## Documentation
 
-### Workflow APIs
+Full docs live in [`docs/`](docs/) (MkDocs):
 
-#### `screen(x, indices=None, percentile=95.0, ...)`
-Runs multiple IER indices, flags respondents by percentile thresholds, and
-returns structured scores, flags, flag counts, per-index errors, and summary
-statistics.
+- [Getting started](docs/getting-started.md)
+- [Index catalog](docs/indices.md)
+- [Screening workflow](docs/workflows/screening.md)
+- [Composite guidance](docs/workflows/composite.md)
+- [Threshold guidance](docs/thresholds.md)
+- [R package notes](docs/r-comparison.md)
+- [Changelog](CHANGELOG.md)
 
-```python
-from ier import screen
+Build locally:
 
-data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3], [1, 5, 1, 5, 1]]
-result = screen(
-    data,
-    indices=["irv", "longstring", "longstring_pattern", "u3_poly", "midpoint"],
-    scale_min=1,
-    scale_max=5,
-)
-
-print(result["scores"])       # Dict of index name -> score array
-print(result["flags"])        # Dict of index name -> boolean flag array
-print(result["flag_counts"])  # Total flags per respondent
-print(result["errors"])       # Indices skipped because of missing config or invalid data
+```bash
+uv sync --extra docs
+uv run mkdocs serve
 ```
 
-Default screen indices are `irv`, `longstring`, `longstring_pattern`, `mahad`,
-`psychsyn`, `person_total`, `markov`, `u3_poly`, `midpoint`, and
-`acquiescence`. Optional requested indices include `evenodd`, `mad`, and `lz`;
-`evenodd` requires `evenodd_factors`, and `mad` requires positive and negative
-item lists.
+Examples:
 
-#### Plotting screen results
-The plotting helpers require the `plot` extra.
-
-```python
-from ier import plot_distributions, plot_flag_counts, plot_flagged_heatmap
-
-fig = plot_distributions(result)
-heatmap = plot_flagged_heatmap(result)
-counts = plot_flag_counts(result)
+```bash
+uv run python examples/basic_screening.py
+uv run python examples/composite_scoring.py
+uv run python examples/careless_responding_walkthrough.py
 ```
 
-### Consistency Indices
+Benchmark:
 
-#### `evenodd(x, factors, diag=False)`
-Computes even-odd consistency by correlating responses to even vs odd items within each factor.
-
-```python
-from ier import evenodd
-
-data = [[1, 2, 3, 4, 5, 6], [2, 3, 4, 5, 6, 7]]
-factors = [3, 3]  # Two factors with 3 items each
-scores = evenodd(data, factors)
-```
-
-#### `psychsyn(x, critval=0.60, anto=False, diag=False, resample_na=False, random_seed=None)` / `psychant(...)`
-Identifies highly correlated item pairs and computes within-person correlations.
-
-```python
-from ier import psychsyn, psychant
-
-data = [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]]
-scores = psychsyn(data, critval=0.5)  # Synonyms
-scores = psychant(data, critval=-0.5)  # Antonyms
-```
-
-#### `individual_reliability(x, n_splits=100, random_seed=None)`
-Estimates response consistency using repeated split-half correlations.
-
-```python
-from ier import individual_reliability, individual_reliability_flag
-
-data = [[1, 2, 1, 2, 1, 2], [1, 5, 2, 4, 3, 3]]
-reliability = individual_reliability(data, n_splits=50)
-flags = individual_reliability_flag(data, threshold=0.3)
-```
-
-#### `person_total(x, na_rm=True)`
-Correlates each person's responses with the sample mean response pattern.
-
-```python
-from ier import person_total
-
-data = [[1, 2, 3, 4, 5], [5, 4, 3, 2, 1], [1, 2, 3, 4, 5]]
-scores = person_total(data)  # [1.0, -1.0, 1.0]
-```
-
-#### `semantic_syn(x, item_pairs, anto=False)` / `semantic_ant(x, item_pairs)`
-Computes consistency for predefined semantic synonym/antonym pairs.
-
-```python
-from ier import semantic_syn, semantic_ant
-
-data = [[1, 1, 5, 5], [1, 2, 5, 4]]
-pairs = [(0, 1), (2, 3)]  # Predefined synonym pairs
-scores = semantic_syn(data, pairs)
-```
-
-#### `guttman(x, na_rm=True, normalize=True)`
-Counts response reversals relative to item difficulty ordering.
-
-```python
-from ier import guttman, guttman_flag
-
-data = [[1, 2, 3, 4, 5], [5, 4, 3, 2, 1]]
-errors = guttman(data)
-flags = guttman_flag(data, threshold=0.5)
-```
-
-#### `mad(x, positive_items=None, negative_items=None, item_pairs=None, scale_max=None, na_rm=True)`
-Mean Absolute Difference between positively and negatively worded items after
-reverse-scoring the negative items. High MAD indicates careless responding
-(not attending to item direction).
-
-```python
-from ier import mad, mad_flag
-
-# Columns 0,2 are positively worded; columns 1,3 are negatively worded
-data = [
-    [5, 1, 5, 1],  # Attentive: high on pos, low on neg
-    [5, 5, 5, 5],  # Careless: ignores item direction
-]
-scores = mad(data, positive_items=[0, 2], negative_items=[1, 3], scale_max=5)
-scores, flags = mad_flag(data, positive_items=[0, 2], negative_items=[1, 3])
-
-# Equivalent paired-item form
-scores = mad(data, item_pairs=[(0, 1), (2, 3)], scale_max=5)
-```
-
-### Response Pattern and Style Indices
-
-#### `longstring(messages, avg=False)`
-Computes the longest or average run of identical consecutive characters in a
-single string, list of strings, or one-dimensional numpy array. Numeric matrix
-longstring scoring is available through `screen(..., indices=["longstring"])`
-and `composite(..., indices=["longstring"])`.
-
-```python
-from ier import longstring
-
-longstring("AAABBBCCDAA")  # ('A', 3)
-longstring("AAABBBCCDAA", avg=True)  # 2.2
-longstring(["11123", "12345", "33333"])  # [('1', 3), ('1', 1), ('3', 5)]
-```
-
-#### `longstring_pattern(x, max_pattern_length=5, na_rm=True)`
-Detects repeating numeric sub-patterns such as 1-2-1-2 or 1-2-3-1-2-3.
-
-```python
-from ier import longstring_pattern
-
-data = [[1, 2, 1, 2, 1, 2], [1, 2, 3, 4, 5, 6]]
-pattern_lengths = longstring_pattern(data)
-```
-
-#### `irv(x, na_rm=True, split=False, num_split=1, split_points=None)`
-Computes intra-individual response variability (standard deviation). Low values
-often indicate straightlining; high values may indicate random responding.
-
-```python
-from ier import irv
-
-data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3]]
-scores = irv(data)
-split_scores = irv(data, split=True, num_split=2)
-```
-
-#### `markov(x, na_rm=True)`
-Computes first-order transition entropy for each response sequence. Low entropy
-indicates highly predictable patterns.
-
-```python
-from ier import markov, markov_flag, markov_summary
-
-data = [[1, 2, 1, 2, 1, 2], [1, 3, 5, 2, 4, 1]]
-entropy = markov(data)
-scores, flags = markov_flag(data, percentile=5.0)
-summary = markov_summary(data)
-```
-
-#### `u3_poly(x, scale_min=None, scale_max=None)`
-Proportion of responses at the scale endpoints.
-
-```python
-from ier import u3_poly
-
-data = [[1, 5, 1, 5, 3], [3, 3, 3, 3, 3]]
-extreme = u3_poly(data, scale_min=1, scale_max=5)
-```
-
-#### `midpoint_responding(x, scale_min=None, scale_max=None, tolerance=0.0)`
-Proportion of midpoint responses.
-
-```python
-from ier import midpoint_responding
-
-data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3]]
-mid = midpoint_responding(data, scale_min=1, scale_max=5)  # [0.2, 1.0]
-```
-
-#### `acquiescence(x, scale_min=None, scale_max=None, positive_items=None, negative_items=None, na_rm=True)`
-Computes normalized agreement tendency. With balanced positive/negative item
-lists, it reverse-scores negative items to isolate agreement bias.
-
-```python
-from ier import acquiescence, acquiescence_flag
-
-data = [[5, 5, 5, 5], [3, 3, 3, 3], [1, 1, 1, 1]]
-scores = acquiescence(data, scale_min=1, scale_max=5)
-scores, flags = acquiescence_flag(data, scale_min=1, scale_max=5, threshold=0.9)
-```
-
-#### `response_pattern(x, scale_min=None, scale_max=None)`
-Returns multiple response style indices at once.
-
-```python
-from ier import response_pattern
-
-data = [[1, 2, 3, 4, 5], [3, 3, 3, 3, 3]]
-patterns = response_pattern(data, scale_min=1, scale_max=5)
-# Returns dict with: extreme, midpoint, acquiescence, variability
-```
-
-#### `infrequency(x, item_indices, expected_responses, proportion=False)`
-Counts failed attention-check or bogus items.
-
-```python
-from ier import infrequency, infrequency_flag
-
-data = [[5, 3, 1], [5, 5, 5], [1, 3, 5]]
-failures = infrequency(data, item_indices=[0, 2], expected_responses=[5, 1])
-scores, flags = infrequency_flag(data, [0, 2], [5, 1], threshold=2)
-```
-
-#### `onset(x, window_size=10, min_items=20, na_rm=True)`
-Detects the item index where a respondent's pattern shifts toward careless
-responding using running IRV and changepoint detection.
-
-```python
-from ier import onset, onset_flag
-
-long_survey_data = [
-    [1, 2, 3, 4, 5] * 4,
-    [2, 4, 3, 5, 1] * 2 + [3] * 10,
-]
-onset_indices = onset(long_survey_data, window_size=10, min_items=20)
-flags = onset_flag(long_survey_data, window_size=10, min_items=20)
-```
-
-### Statistical Outlier Detection
-
-#### `mahad(x, flag=False, confidence=0.95, na_rm=False, method='chi2')`
-Computes Mahalanobis distance for multivariate outlier detection. The default
-`method="chi2"` requires the `full` extra; `method="iqr"` and `method="zscore"`
-can be used without SciPy for flagging.
-
-```python
-from ier import mahad, mahad_qqplot
-
-data = [[1, 2, 3], [2, 3, 4], [3, 4, 5], [10, 10, 10]]
-distances = mahad(data, method='iqr')
-distances, flags = mahad(data, flag=True, method='iqr')
-
-# Requires insufficient-effort[full]
-distances, flags = mahad(data, flag=True, confidence=0.95, method='chi2')
-theoretical, observed = mahad_qqplot(data)
-```
-
-#### `lz(x, difficulty=None, discrimination=None, theta=None, model='2pl')`
-Standardized log-likelihood (lz) person-fit statistic based on Item Response Theory. Negative values indicate aberrant response patterns.
-
-When `difficulty`, `discrimination`, or `theta` are omitted, `ier` estimates
-them from the same response matrix as a convenience fallback. Treat the
-resulting lz values as screening statistics rather than fully calibrated IRT
-person-fit tests. Polytomous responses are dichotomized at the observed
-midpoint before scoring, which discards category information.
-
-```python
-from ier import lz, lz_flag
-
-# Binary response data (0/1)
-data = [
-    [1, 1, 1, 0, 0, 0],  # Normal pattern
-    [0, 0, 0, 1, 1, 1],  # Aberrant pattern (fails easy, passes hard)
-]
-scores = lz(data)  # Negative = suspicious
-scores, flags = lz_flag(data, threshold=-1.96)
-
-# Use 1PL (Rasch) model
-scores = lz(data, model='1pl')
-
-# Provide custom item parameters
-scores = lz(data, difficulty=[-1, -0.5, 0, 0.5, 1, 1.5])
-```
-
-### Response Time Indices
-
-#### `response_time(times, metric='median')`
-Computes response time statistics per person.
-
-```python
-from ier import (
-    response_time,
-    response_time_consistency,
-    response_time_flag,
-    response_time_mixture,
-)
-
-times = [[2.1, 3.4, 2.8], [0.5, 0.4, 0.6], [2.5, 2.3, 2.7]]
-
-avg_times = response_time(times, metric='mean')
-med_times = response_time(times, metric='median')
-min_times = response_time(times, metric='min')
-
-# Flag fast responders
-flags = response_time_flag(times, threshold=1.0)
-
-# Coefficient of variation (low = suspiciously uniform)
-cv = response_time_consistency(times)
-
-# Requires insufficient-effort[full]
-fast_component_probability = response_time_mixture(times, random_seed=42)
-```
-
-### Composite Index
-
-#### `composite(x, indices=None, method='mean', standardize=True, return_diagnostics=False, ...)`
-Combines multiple IER indices into a single composite score. Higher scores
-indicate greater likelihood of careless responding.
-
-```python
-from ier import composite, composite_flag, composite_probability, composite_summary
-
-data = [
-    [1, 2, 3, 4, 5, 4, 3, 2, 1, 2],  # Normal
-    [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],  # Straightliner
-    [1, 5, 1, 5, 1, 5, 1, 5, 1, 5],  # Alternating
-]
-base_indices = ['irv', 'longstring', 'person_total', 'markov']
-
-# Select NumPy-only indices
-scores = composite(data, indices=base_indices)
-
-# Include configured indices
-scores = composite(
-    data,
-    indices=['irv', 'longstring', 'mad'],
-    mad_positive_items=[0, 2, 4],
-    mad_negative_items=[1, 3, 5],
-    mad_scale_max=5,
-)
-
-# Different combination methods
-scores = composite(data, indices=base_indices, method='sum')  # Sum of z-scores
-scores = composite(data, indices=base_indices, method='max')  # Maximum z-score
-scores = composite(data, method='best_subset')  # IRV, longstring, lz; MAD if configured
-
-# Flag careless responders
-scores, flags = composite_flag(data, indices=base_indices, threshold=1.5)
-scores, flags = composite_flag(data, indices=base_indices, percentile=95.0)
-
-# Optional diagnostics for skipped indices
-scores, diagnostics = composite(
-    data,
-    indices=['irv', 'mad'],
-    return_diagnostics=True,
-)
-
-# Detailed summary with individual index scores
-summary = composite_summary(data, indices=base_indices)
-print(summary['indices_used'])  # ['irv', 'longstring', 'person_total', 'markov']
-print(summary['indices'])       # Dict of individual index scores
-
-# Sample-relative logistic transform, not a calibrated probability
-probability_scores = composite_probability(data, indices=['irv', 'longstring'])
-```
-
-`composite_probability()` returns a logistic transform of the sample-relative
-standardized composite score. It is bounded between 0 and 1, but it is not a
-calibrated probability of IER unless you validate and calibrate it against
-labeled data from a comparable survey context.
-
-Default composite indices are `irv`, `longstring`, `mahad`, `psychsyn`, and
-`person_total`. Additional allowed composite indices are `evenodd`, `mad`,
-`markov`, `longstring_pattern`, and `lz`; `u3_poly`, `midpoint`, and
-`acquiescence` are screening-only response-style indices.
-
-## Working with DataFrames
-
-Functions accept array-like inputs. DataFrame objects that expose `__array__`
-can be passed directly; otherwise pass their numpy representation.
-
-```python
-import pandas as pd
-import polars as pl
-from ier import irv
-
-# Pandas
-df_pandas = pd.DataFrame([[1, 2, 3], [4, 5, 6]])
-scores = irv(df_pandas)
-
-# Polars
-df_polars = pl.DataFrame([[1, 2, 3], [4, 5, 6]])
-scores = irv(df_polars.to_numpy())
-```
-
-## Handling Missing Data
-
-Most functions handle NaN values appropriately:
-
-```python
-import numpy as np
-from ier import irv, mahad
-
-data = np.array([
-    [1, 2],
-    [2, 3],
-    [np.nan, 4],
-    [3, 4],
-    [10, 10],
-], dtype=float)
-
-irv_scores = irv(data, na_rm=True)
-mahad_scores = mahad(data, na_rm=True, method="iqr")
+```bash
+uv run python benchmarks/bench_screen.py
 ```
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
-quality checks, and release instructions.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT License — see [LICENSE](LICENSE).
 
 ## Citation
 
@@ -537,3 +110,4 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 - Curran, P. G. (2016). Methods for the detection of carelessly invalid responses in survey data. *Journal of Experimental Social Psychology*, 66, 4-19.
 - Dunn, A. M., Heggestad, E. D., Shanock, L. R., & Theilgard, N. (2018). Intra-individual response variability as an indicator of insufficient effort responding. *Journal of Business and Psychology*, 33(1), 105-121.
+- Meade, A. W., & Craig, S. B. (2012). Identifying careless responses in survey data. *Psychological Methods*, 17(3), 437-455.

--- a/benchmarks/bench_screen.py
+++ b/benchmarks/bench_screen.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Benchmark default screen() on synthetic survey matrices.
+
+Usage:
+    uv run python benchmarks/bench_screen.py
+    uv run python benchmarks/bench_screen.py --respondents 2000 --items 50 --repeats 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import numpy as np
+
+from ier import screen
+
+
+def _make_data(n_respondents: int, n_items: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    data = rng.integers(1, 6, size=(n_respondents, n_items)).astype(float)
+    # Inject a few pathological rows
+    data[0, :] = 3.0
+    if n_items >= 6:
+        data[1, :] = np.tile([1.0, 5.0], n_items // 2 + 1)[:n_items]
+    return data
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--respondents", type=int, default=500)
+    parser.add_argument("--items", type=int, default=30)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    data = _make_data(args.respondents, args.items, args.seed)
+
+    for _ in range(args.warmup):
+        screen(data, scale_min=1, scale_max=5)
+
+    timings: list[float] = []
+    for _ in range(args.repeats):
+        start = time.perf_counter()
+        result = screen(data, scale_min=1, scale_max=5)
+        timings.append(time.perf_counter() - start)
+
+    print(f"shape={data.shape} indices={result['n_indices']}")
+    print(
+        "screen seconds: "
+        f"median={statistics.median(timings):.4f} "
+        f"mean={statistics.mean(timings):.4f} "
+        f"min={min(timings):.4f} max={max(timings):.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,37 @@
+# API Reference
+
+::: ier
+    options:
+      members:
+        - screen
+        - composite
+        - composite_flag
+        - composite_probability
+        - composite_summary
+        - irv
+        - longstring
+        - longstring_pattern
+        - mahad
+        - psychsyn
+        - psychant
+        - person_total
+        - markov
+        - u3_poly
+        - midpoint_responding
+        - acquiescence
+        - guttman
+        - individual_reliability
+        - onset
+        - evenodd
+        - mad
+        - lz
+        - semantic_syn
+        - semantic_ant
+        - infrequency
+        - response_time
+        - response_time_consistency
+        - response_time_flag
+        - response_time_mixture
+        - plot_distributions
+        - plot_flag_counts
+        - plot_flagged_heatmap

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+--8<-- "CHANGELOG.md"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,76 @@
+# Getting Started
+
+## Installation
+
+### From PyPI
+
+```bash
+pip install insufficient-effort
+```
+
+### With optional dependencies
+
+```bash
+pip install "insufficient-effort[full]"
+pip install "insufficient-effort[plot]"
+pip install "insufficient-effort[full,plot]"
+```
+
+| Extra | Provides |
+|-------|----------|
+| *(none)* | NumPy-only indices and default `screen()` / `composite()` |
+| `full` | SciPy for `mahad(..., method="chi2", flag=True)` and `response_time_mixture()` |
+| `plot` | matplotlib helpers (`plot_distributions`, etc.) |
+
+### From source (development)
+
+```bash
+git clone https://github.com/Cameron-Lyons/ier.git
+cd ier
+uv sync --extra dev
+```
+
+## Input shapes
+
+Functions expect a matrix where **rows are respondents** and **columns are items**.
+Accepted inputs:
+
+- nested lists / tuples
+- NumPy arrays
+- objects with `__array__` (e.g. pandas DataFrames)
+
+Polars DataFrames should usually be converted with `.to_numpy()`.
+
+```python
+import pandas as pd
+from ier import irv
+
+df = pd.DataFrame([[1, 2, 3], [4, 5, 6]])
+scores = irv(df)
+```
+
+## Missing data
+
+Most scorers accept `na_rm=True` (often the default) to skip incomplete rows or
+pairwise comparisons rather than failing on NaNs.
+
+```python
+import numpy as np
+from ier import irv, mahad
+
+data = np.array([
+    [1, 2],
+    [2, 3],
+    [np.nan, 4],
+    [3, 4],
+], dtype=float)
+
+irv(data, na_rm=True)
+mahad(data, na_rm=True, method="iqr")
+```
+
+## Next steps
+
+- Run multi-index screening with [`screen()`](workflows/screening.md)
+- Combine signals with [`composite()`](workflows/composite.md)
+- Browse the [index catalog](indices.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+# IER
+
+Python library for detecting **Insufficient Effort Responding (IER)** / careless
+responding in survey data.
+
+## Install
+
+```bash
+pip install insufficient-effort
+```
+
+Optional extras:
+
+```bash
+pip install "insufficient-effort[full]"   # SciPy-backed mahad chi2 flagging, RT mixture
+pip install "insufficient-effort[plot]"   # matplotlib visualizations
+```
+
+Base install is NumPy-only. Default `screen()` and `composite()` work without SciPy.
+
+## Quick start
+
+```python
+import numpy as np
+from ier import composite, screen
+
+data = np.array([
+    [1, 2, 3, 4, 5, 4],
+    [3, 3, 3, 3, 3, 3],  # straightlining
+    [1, 5, 1, 5, 1, 5],
+], dtype=float)
+
+result = screen(data, scale_min=1, scale_max=5)
+print(result["flag_counts"])
+
+scores = composite(data, indices=["irv", "longstring", "person_total"])
+print(scores)
+```
+
+## Learn more
+
+- [Getting started](getting-started.md)
+- [Index catalog](indices.md)
+- [Screening workflow](workflows/screening.md)
+- [Composite guidance](workflows/composite.md)
+- [Threshold guidance](thresholds.md)
+- [R package notes](r-comparison.md)
+- [API reference](api.md)
+- [Changelog](changelog.md)
+
+## Citation
+
+```bibtex
+@software{ier2026,
+  title={IER: Python package for detecting Insufficient Effort Responding},
+  author={Lyons, Cameron},
+  year={2026},
+  url={https://github.com/Cameron-Lyons/ier}
+}
+```

--- a/docs/indices.md
+++ b/docs/indices.md
@@ -1,0 +1,52 @@
+# Index Catalog
+
+Registry-backed indices can be selected in `screen()` / `composite()`. Response-time
+helpers use a different input domain and are listed separately.
+
+## Matrix indices
+
+| Name | Construct | Flag when | Screen default | Composite | Extra config |
+|------|-----------|-----------|----------------|-----------|--------------|
+| `irv` | Intra-individual response variability | low | yes | yes | — |
+| `longstring` | Max consecutive identical responses | high | yes | yes | — |
+| `longstring_pattern` | Repeating response patterns | high | yes | yes | `longstring_max_pattern_length` |
+| `mahad` | Mahalanobis distance (multivariate outlier) | high | yes | yes | — |
+| `psychsyn` | Psychometric synonym consistency | low | yes | yes | `psychsyn_critval` |
+| `psychant` | Psychometric antonym consistency | low | no | yes | `psychant_critval` |
+| `person_total` | Extreme total scores | low* | yes | yes | — |
+| `markov` | Transition entropy | low | yes | yes | — |
+| `u3_poly` | Polytomous person-fit / Guttman-like | high | yes | no | `scale_min` / `scale_max` |
+| `midpoint` | Midpoint responding | high | yes | no | `scale_min` / `scale_max`, `midpoint_tolerance` |
+| `acquiescence` | Agreeing / yea-saying | high | yes | no | scale bounds; optional item lists |
+| `guttman` | Guttman errors | high | yes | yes | `guttman_normalize` |
+| `individual_reliability` | Split-half individual reliability | low | no | yes | `reliability_n_splits`, seed |
+| `onset` | Carelessness onset item index | present | no | no | `onset_window_size`, `onset_min_items` |
+| `evenodd` | Even-odd consistency | low | no | yes | `evenodd_factors` |
+| `mad` | Maximum absolute deviation (antonyms) | high | no | yes | MAD item lists / `mad_scale_max` |
+| `lz` | lz person-fit | low | no | yes | optional IRT params via direct API |
+| `semantic_syn` | Predefined synonym consistency | low | no | yes | `semantic_item_pairs` |
+| `semantic_ant` | Predefined antonym consistency | low | no | yes | `semantic_item_pairs` |
+| `infrequency` | Failed attention / bogus items | high | no | yes | item indices + expected responses |
+
+\* `person_total` flags unusually low totals under the default low-direction
+percentile rule; interpret in context of your scale coding.
+
+## Response-time indices (standalone)
+
+Call these with timing matrices (`respondents × items` or per-respondent times):
+
+| Function | Signal | Typical flag |
+|----------|--------|--------------|
+| `response_time` | Central tendency of RT | low (too fast) |
+| `response_time_consistency` | RT coefficient of variation | low (too uniform) |
+| `response_time_flag` | Percentile / threshold flagging | low |
+| `response_time_mixture` | Mixture P(fast component); needs SciPy | high |
+
+## Plot helpers
+
+Requires `insufficient-effort[plot]`:
+
+- `plot_distributions(screen_result)`
+- `plot_flag_counts(screen_result)`
+- `plot_flagged_heatmap(screen_result)`
+- `mahad_qqplot(...)` (also needs SciPy)

--- a/docs/r-comparison.md
+++ b/docs/r-comparison.md
@@ -1,0 +1,42 @@
+# Notes Relative to R Packages
+
+Several R packages implement overlapping careless-responding indices. IER aims
+to provide a NumPy-first Python API with typed orchestration via `screen()` and
+`composite()`.
+
+## Related R ecosystems
+
+Common reference points in the literature and tooling include packages in the
+careless-responding / person-fit space (names vary by CRAN status and forks),
+often covering:
+
+- longstring / IRV-style pattern indices
+- psychometric synonyms / antonyms
+- Mahalanobis distance outliers
+- response-time summaries
+- attention-check scoring
+
+Exact function names, defaults, and NA handling differ across implementations.
+Do **not** expect bit-identical scores without aligning:
+
+- missing-data policy (`na_rm`)
+- correlation critical values (`psychsyn_critval`)
+- Mahalanobis flagging method (`chi2` vs `iqr` vs `zscore`)
+- whether scores are normalized (e.g., Guttman proportions)
+- random seeds for resampling methods (`individual_reliability`)
+
+## Suggested validation workflow
+
+If you need parity with an existing R pipeline:
+
+1. Export the same respondent × item matrix from both environments.
+2. Compare one index at a time on complete cases.
+3. Match options explicitly (critical values, normalization, seeds).
+4. Treat residual differences as implementation notes in your methods section.
+
+## What IER adds for Python users
+
+- Unified `screen()` / `composite()` registry with soft per-index errors
+- Strict typing (`py.typed`) and CI across Python 3.11–3.14
+- Optional SciPy / matplotlib extras without forcing them on base installs
+- Explicit documentation that composite logistic scores are uncalibrated

--- a/docs/thresholds.md
+++ b/docs/thresholds.md
@@ -1,0 +1,42 @@
+# Threshold Guidance
+
+There is no universal cutoff that separates attentive from careless responders
+across all surveys. Thresholds depend on item content, scale length, incentive
+structure, and base rate of IER.
+
+## Recommended practice
+
+1. **Prefer multi-index agreement.** Flag respondents who are extreme on several
+   independent families (consistency, pattern, outlier, attention check) rather
+   than a single index.
+2. **Use sample-relative percentiles carefully.** Default `screen(..., percentile=95)`
+   and `composite_flag(..., percentile=95)` are convenient starting points, not
+   gold standards. With small *N*, percentiles are unstable.
+3. **Anchor with designed checks.** Infrequency / instructed-response items give
+   confirmatory evidence when available (`infrequency`).
+4. **Inspect before excluding.** Review open-ended responses, timestamps, and
+   substantive patterns before listwise deletion.
+5. **Report sensitivity.** Show how results change under alternate cutoffs
+   (e.g., 90th vs 95th vs 99th percentile).
+
+## Literature-informed starting points
+
+These are illustrative defaults from common practice, not package guarantees:
+
+| Signal | Common starting rule | Notes |
+|--------|----------------------|-------|
+| Longstring | Flag very long consecutive identical strings | Depends on scale length and response options |
+| IRV | Flag unusually low variability | Straightlining / near-straightlining |
+| Psychometric synonyms | Low within-person synonym correlations | Needs enough correlated pairs |
+| Even-odd | Low even-odd consistency | Requires known factor lengths |
+| Infrequency | ≥1 failed attention check | Threshold of 1 is common for short batteries |
+| Response time | Very fast page/item times | Absolute cutoffs are survey-specific |
+| Mahalanobis | High multivariate distance | chi² flagging needs SciPy; screening uses percentiles |
+
+See Curran (2016) and Meade & Craig (2012) for broader methodological discussion.
+
+## Composite scores
+
+Treat `composite()` / `composite_probability()` as **ranking tools** within a
+sample. Do not interpret logistic composite values as calibrated probabilities
+unless you validate them on labeled data from a similar context.

--- a/docs/workflows/composite.md
+++ b/docs/workflows/composite.md
@@ -1,0 +1,51 @@
+# Composite Scores
+
+`composite()` combines multiple IER indices into one sample-relative score.
+Higher values indicate stronger careless-responding signal **within the sample**.
+
+```python
+from ier import composite, composite_probability
+
+scores = composite(data, indices=["irv", "longstring", "person_total", "markov"])
+ranks = composite_probability(data, indices=["irv", "longstring"])
+```
+
+## Important caveats
+
+!!! warning "Not a calibrated probability"
+    `composite_probability()` applies a logistic transform to standardized
+    composite scores. Values lie in `[0, 1]` but are **not** validated
+    probabilities of IER unless you calibrate against labeled data from a
+    comparable survey.
+
+Practical guidance:
+
+1. Prefer multi-index agreement over any single cutoff.
+2. Review flagged cases substantively (open text, completion time, attention checks).
+3. Report which indices and combination method you used.
+4. Use `method="best_subset"` when you want the Curran/Meade-Craig style mix of
+   consistency, pattern, and (optionally) MAD signals.
+
+## Allowed indices
+
+Composite-enabled indices include:
+
+`irv`, `longstring`, `longstring_pattern`, `mahad`, `psychsyn`, `psychant`,
+`person_total`, `markov`, `guttman`, `individual_reliability`, `evenodd`, `mad`,
+`lz`, `semantic_syn`, `semantic_ant`, `infrequency`
+
+Screening-only response-style indices (`u3_poly`, `midpoint`, `acquiescence`,
+`onset`) are excluded from composite combination because they measure different
+constructs and can dilute pattern/consistency signals.
+
+## Combination methods
+
+| Method | Behavior |
+|--------|----------|
+| `mean` | Mean of (optionally standardized) directed scores |
+| `sum` | Sum of directed scores |
+| `max` | Max of directed scores |
+| `best_subset` | Forces `["mad", "irv", "longstring", "lz"]` when MAD items are provided, else `["irv", "longstring", "lz"]`, combined with `mean` |
+
+Direction is handled automatically: low-is-bad indices are sign-flipped before
+combination so that higher composite always means more IER signal.

--- a/docs/workflows/screening.md
+++ b/docs/workflows/screening.md
@@ -1,0 +1,73 @@
+# Screening Workflow
+
+`screen()` runs multiple IER indices, applies flagging rules, and returns a
+structured result.
+
+```python
+from ier import screen
+
+result = screen(data, scale_min=1, scale_max=5)
+print(result["indices_used"])
+print(result["flag_counts"])
+print(result["errors"])
+```
+
+## Result keys
+
+| Key | Meaning |
+|-----|---------|
+| `scores` | Per-index score arrays |
+| `flags` | Per-index boolean flags |
+| `flag_counts` | Total flags per respondent |
+| `indices_used` | Successfully computed indices |
+| `errors` | Soft failures (missing config, invalid data for an index) |
+| `summary` | Mean/std/min/max/`n_flagged` per index |
+| `n_respondents` / `n_indices` | Size metadata |
+
+## Defaults
+
+Default indices are NumPy-only and require no extra item metadata:
+
+`irv`, `longstring`, `longstring_pattern`, `mahad`, `psychsyn`, `person_total`,
+`markov`, `u3_poly`, `midpoint`, `acquiescence`, `guttman`
+
+Mahalanobis distances in screening use a NumPy-safe path; SciPy is only needed
+when you call `mahad(..., flag=True, method="chi2")` directly.
+
+## Config-gated indices
+
+Pass configuration to include indices that need survey metadata:
+
+```python
+result = screen(
+    data,
+    indices=["evenodd", "mad", "semantic_syn", "infrequency"],
+    evenodd_factors=[5, 5],
+    mad_positive_items=[0, 1, 2],
+    mad_negative_items=[3, 4, 5],
+    semantic_item_pairs=[(0, 1), (2, 3)],
+    infrequency_item_indices=[9],
+    infrequency_expected_responses=[5],
+)
+```
+
+Missing required config is recorded in `result["errors"]` instead of aborting
+the whole screening run.
+
+## Flagging
+
+- Most indices use percentile thresholds (`percentile=95` by default).
+- High-direction indices flag above the percentile; low-direction indices flag
+  below `100 - percentile`.
+- `onset` uses presence flagging: any detected changepoint is flagged.
+
+## Response times
+
+`response_time*` helpers take **timing matrices**, not item responses. Call them
+directly rather than through `screen()`.
+
+```python
+from ier import response_time_flag
+
+flags = response_time_flag(times, cutoff_percentile=5)
+```

--- a/examples/basic_screening.py
+++ b/examples/basic_screening.py
@@ -1,0 +1,15 @@
+"""Basic multi-index screening example."""
+
+import numpy as np
+
+from ier import screen
+
+rng = np.random.default_rng(7)
+data = rng.integers(1, 6, size=(40, 12)).astype(float)
+data[0, :] = 3.0  # straightliner
+data[1, :] = np.tile([1.0, 5.0], 6)  # alternating
+
+result = screen(data, scale_min=1, scale_max=5)
+print("indices:", result["indices_used"])
+print("top flagged respondents:", np.argsort(result["flag_counts"])[::-1][:5])
+print("flag counts:", result["flag_counts"][:5], "...")

--- a/examples/careless_responding_walkthrough.py
+++ b/examples/careless_responding_walkthrough.py
@@ -1,0 +1,56 @@
+"""
+# Careless responding walkthrough
+
+This notebook-style script mirrors a typical analysis path:
+
+1. Simulate attentive vs careless respondents
+2. Screen with multiple indices
+3. Inspect multi-index agreement
+4. Form a composite ranking
+
+Run with:
+
+```bash
+uv run python examples/careless_responding_walkthrough.py
+```
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ier import composite, screen
+
+
+def simulate(n_attentive: int = 80, n_careless: int = 20, n_items: int = 20, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    attentive = rng.integers(1, 6, size=(n_attentive, n_items)).astype(float)
+    careless = np.full((n_careless, n_items), 3.0)
+    # Mix in a few alternating careless rows
+    for i in range(0, n_careless, 4):
+        careless[i, :] = np.tile([1.0, 5.0], n_items // 2)
+    labels = np.array([0] * n_attentive + [1] * n_careless)
+    data = np.vstack([attentive, careless])
+    order = rng.permutation(data.shape[0])
+    return data[order], labels[order]
+
+
+def main() -> None:
+    data, labels = simulate()
+    result = screen(data, scale_min=1, scale_max=5)
+    agreement = result["flag_counts"] >= 2
+    hit_rate = float(np.mean(agreement[labels == 1]))
+    false_alarm = float(np.mean(agreement[labels == 0]))
+
+    ranking = composite(data, indices=["irv", "longstring", "person_total", "markov"])
+    top = np.argsort(ranking)[::-1][:10]
+    precision_at_10 = float(np.mean(labels[top]))
+
+    print(f"respondents={data.shape[0]} items={data.shape[1]}")
+    print(f"indices_used={result['indices_used']}")
+    print(f"multi-index (>=2 flags) hit_rate={hit_rate:.2f} false_alarm={false_alarm:.2f}")
+    print(f"composite precision@10={precision_at_10:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/composite_scoring.py
+++ b/examples/composite_scoring.py
@@ -1,0 +1,20 @@
+"""Composite scoring example with explicit NumPy-only indices."""
+
+import numpy as np
+
+from ier import composite, composite_probability
+
+rng = np.random.default_rng(11)
+data = rng.integers(1, 6, size=(50, 10)).astype(float)
+data[2, :] = 3.0
+
+indices = ["irv", "longstring", "person_total", "markov", "guttman"]
+scores = composite(data, indices=indices)
+probs = composite_probability(data, indices=indices)
+
+print("composite head:", np.round(scores[:5], 3))
+print("uncalibrated logistic head:", np.round(probs[:5], 3))
+print(
+    "note: logistic values rank respondents within-sample; "
+    "they are not calibrated IER probabilities."
+)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,59 @@
+site_name: IER
+site_description: Detect Insufficient Effort Responding in survey data
+site_url: https://cameron-lyons.github.io/ier/
+repo_url: https://github.com/Cameron-Lyons/ier
+repo_name: Cameron-Lyons/ier
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - content.code.copy
+    - search.suggest
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Workflows:
+      - Screening: workflows/screening.md
+      - Composite Scores: workflows/composite.md
+  - Index Catalog: indices.md
+  - Threshold Guidance: thresholds.md
+  - R Package Notes: r-comparison.md
+  - Changelog: changelog.md
+  - API Reference: api.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: false
+            members_order: source
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.snippets:
+      base_path: [., ..]
+      check_paths: true
+  - pymdownx.superfences
+  - tables
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,25 +4,40 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "insufficient-effort"
-version = "1.6.3"
+version = "1.7.0"
 authors = [{ name = "Cameron Lyons", email = "cameron.lyons2@gmail.com" }]
 description = "Python library for detecting Insufficient Effort Responding (IER) in survey data"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = ["numpy>=1.26.0,<2.5"]
 classifiers = [
-  "Programming Language :: Python :: 3",
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "Typing :: Typed",
 ]
 
 [project.optional-dependencies]
 full = ["scipy>=1.11.0,<1.18"]
 plot = ["matplotlib>=3.8.0,<4"]
+docs = [
+    "mkdocs>=1.6.0,<2",
+    "mkdocs-material>=9.5.0,<10",
+    "mkdocstrings[python]>=0.26.0,<1",
+]
 dev = [
     "scipy>=1.16.3,<1.18",
     "scipy-stubs>=1.16.3,<1.18",
     "matplotlib>=3.8.0,<4",
+    "pandas>=2.2.0,<3",
+    "polars>=1.0.0,<2",
     "pytest>=9.0.3,<10",
     "pytest-cov>=7.0.0,<8",
     "mypy>=1.19.0,<3",
@@ -35,6 +50,9 @@ dev = [
     "pillow>=12.2.0,<13",
     "pygments>=2.20.0,<3",
     "requests>=2.33.0,<3",
+    "mkdocs>=1.6.0,<2",
+    "mkdocs-material>=9.5.0,<10",
+    "mkdocstrings[python]>=0.26.0,<1",
 ]
 
 [tool.setuptools]
@@ -49,6 +67,8 @@ ier = ["py.typed"]
 [project.urls]
 "Homepage" = "https://github.com/Cameron-Lyons/ier"
 "Bug Tracker" = "https://github.com/Cameron-Lyons/ier/issues"
+"Changelog" = "https://github.com/Cameron-Lyons/ier/blob/main/CHANGELOG.md"
+"Documentation" = "https://cameron-lyons.github.io/ier/"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/ier/_registry.py
+++ b/src/ier/_registry.py
@@ -8,17 +8,23 @@ import numpy as np
 
 from ier.acquiescence import acquiescence
 from ier.evenodd import evenodd
+from ier.guttman import guttman
+from ier.infrequency import infrequency
 from ier.irv import irv
 from ier.longstring import longstring_pattern, longstring_scores
 from ier.lz import lz
 from ier.mad import run_mad_index
 from ier.mahad import mahad
 from ier.markov import markov
+from ier.onset import onset
 from ier.person_total import person_total
-from ier.psychsyn import psychsyn
+from ier.psychsyn import psychant, psychsyn
+from ier.reliability import individual_reliability
+from ier.semantic import semantic_ant, semantic_syn
 from ier.u3_poly import midpoint_responding, u3_poly
 
 FlagDirection = Literal["high", "low"]
+FlagMode = Literal["percentile", "present"]
 
 
 @dataclass(frozen=True)
@@ -27,12 +33,26 @@ class IndexOptions:
 
     na_rm: bool = True
     psychsyn_critval: float = 0.6
+    psychant_critval: float = -0.6
     evenodd_factors: list[int] | None = None
     mad_positive_items: list[int] | None = None
     mad_negative_items: list[int] | None = None
     mad_scale_max: int | None = None
     scale_min: float | None = None
     scale_max: float | None = None
+    acquiescence_positive_items: list[int] | None = None
+    acquiescence_negative_items: list[int] | None = None
+    longstring_max_pattern_length: int = 5
+    midpoint_tolerance: float = 0.0
+    guttman_normalize: bool = True
+    onset_window_size: int = 10
+    onset_min_items: int = 20
+    reliability_n_splits: int = 100
+    reliability_random_seed: int | None = None
+    semantic_item_pairs: list[tuple[int, int]] | None = None
+    infrequency_item_indices: list[int] | None = None
+    infrequency_expected_responses: list[float] | None = None
+    infrequency_proportion: bool = False
 
 
 def build_index_options(
@@ -45,17 +65,45 @@ def build_index_options(
     *,
     scale_min: float | None = None,
     scale_max: float | None = None,
+    psychant_critval: float = -0.6,
+    acquiescence_positive_items: list[int] | None = None,
+    acquiescence_negative_items: list[int] | None = None,
+    longstring_max_pattern_length: int = 5,
+    midpoint_tolerance: float = 0.0,
+    guttman_normalize: bool = True,
+    onset_window_size: int = 10,
+    onset_min_items: int = 20,
+    reliability_n_splits: int = 100,
+    reliability_random_seed: int | None = None,
+    semantic_item_pairs: list[tuple[int, int]] | None = None,
+    infrequency_item_indices: list[int] | None = None,
+    infrequency_expected_responses: list[float] | None = None,
+    infrequency_proportion: bool = False,
 ) -> IndexOptions:
     """Build shared option state for registered index scorers."""
     return IndexOptions(
-        na_rm,
-        psychsyn_critval,
-        evenodd_factors,
-        mad_positive_items,
-        mad_negative_items,
-        mad_scale_max,
-        scale_min,
-        scale_max,
+        na_rm=na_rm,
+        psychsyn_critval=psychsyn_critval,
+        psychant_critval=psychant_critval,
+        evenodd_factors=evenodd_factors,
+        mad_positive_items=mad_positive_items,
+        mad_negative_items=mad_negative_items,
+        mad_scale_max=mad_scale_max,
+        scale_min=scale_min,
+        scale_max=scale_max,
+        acquiescence_positive_items=acquiescence_positive_items,
+        acquiescence_negative_items=acquiescence_negative_items,
+        longstring_max_pattern_length=longstring_max_pattern_length,
+        midpoint_tolerance=midpoint_tolerance,
+        guttman_normalize=guttman_normalize,
+        onset_window_size=onset_window_size,
+        onset_min_items=onset_min_items,
+        reliability_n_splits=reliability_n_splits,
+        reliability_random_seed=reliability_random_seed,
+        semantic_item_pairs=semantic_item_pairs,
+        infrequency_item_indices=infrequency_item_indices,
+        infrequency_expected_responses=infrequency_expected_responses,
+        infrequency_proportion=infrequency_proportion,
     )
 
 
@@ -70,6 +118,7 @@ class IndexSpec:
     default_screen: bool = False
     default_composite: bool = False
     composite_enabled: bool = True
+    flag_mode: FlagMode = "percentile"
     required_error: Callable[[IndexOptions], str | None] | None = None
 
 
@@ -85,8 +134,24 @@ def _require_mad_items(options: IndexOptions) -> str | None:
     return None
 
 
+def _require_semantic_pairs(options: IndexOptions) -> str | None:
+    if options.semantic_item_pairs is None:
+        return "semantic_item_pairs must be provided when using semantic_syn or semantic_ant"
+    return None
+
+
+def _require_infrequency_config(options: IndexOptions) -> str | None:
+    if options.infrequency_item_indices is None or options.infrequency_expected_responses is None:
+        return (
+            "infrequency_item_indices and infrequency_expected_responses "
+            "must be provided when using infrequency"
+        )
+    return None
+
+
 def _mahad_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
-    result = mahad(x, na_rm=options.na_rm)
+    # Distances are NumPy-only; screen/composite apply their own flagging.
+    result = mahad(x, na_rm=options.na_rm, method="iqr")
     if not isinstance(result, np.ndarray):
         raise ValueError("mahad returned non-array output")
     return result
@@ -97,6 +162,14 @@ def _psychsyn_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
         result = psychsyn(x, critval=options.psychsyn_critval, resample_na=options.na_rm)
     if not isinstance(result, np.ndarray):
         raise ValueError("psychsyn returned non-array output")
+    return result
+
+
+def _psychant_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
+    with np.errstate(divide="ignore", invalid="ignore"):
+        result = psychant(x, critval=options.psychant_critval, resample_na=options.na_rm)
+    if not isinstance(result, np.ndarray):
+        raise ValueError("psychant returned non-array output")
     return result
 
 
@@ -119,6 +192,64 @@ def _mad_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
     )
 
 
+def _acquiescence_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
+    return acquiescence(
+        x,
+        scale_min=options.scale_min,
+        scale_max=options.scale_max,
+        positive_items=options.acquiescence_positive_items,
+        negative_items=options.acquiescence_negative_items,
+        na_rm=options.na_rm,
+    )
+
+
+def _guttman_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
+    return guttman(x, na_rm=options.na_rm, normalize=options.guttman_normalize)
+
+
+def _onset_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
+    return onset(
+        x,
+        window_size=options.onset_window_size,
+        min_items=options.onset_min_items,
+        na_rm=options.na_rm,
+    )
+
+
+def _reliability_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
+    return individual_reliability(
+        x,
+        n_splits=options.reliability_n_splits,
+        random_seed=options.reliability_random_seed,
+    )
+
+
+def _semantic_syn_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
+    if options.semantic_item_pairs is None:
+        raise ValueError("semantic_item_pairs must be provided when using semantic_syn")
+    return semantic_syn(x, item_pairs=options.semantic_item_pairs, anto=False)
+
+
+def _semantic_ant_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
+    if options.semantic_item_pairs is None:
+        raise ValueError("semantic_item_pairs must be provided when using semantic_ant")
+    return semantic_ant(x, item_pairs=options.semantic_item_pairs)
+
+
+def _infrequency_scores(x: np.ndarray, options: IndexOptions) -> np.ndarray:
+    if options.infrequency_item_indices is None or options.infrequency_expected_responses is None:
+        raise ValueError(
+            "infrequency_item_indices and infrequency_expected_responses "
+            "must be provided when using infrequency"
+        )
+    return infrequency(
+        x,
+        item_indices=options.infrequency_item_indices,
+        expected_responses=options.infrequency_expected_responses,
+        proportion=options.infrequency_proportion,
+    )
+
+
 INDEX_REGISTRY: dict[str, IndexSpec] = {
     "irv": IndexSpec(
         name="irv",
@@ -137,7 +268,11 @@ INDEX_REGISTRY: dict[str, IndexSpec] = {
     ),
     "longstring_pattern": IndexSpec(
         name="longstring_pattern",
-        scorer=lambda x, options: longstring_pattern(x, na_rm=options.na_rm),
+        scorer=lambda x, options: longstring_pattern(
+            x,
+            max_pattern_length=options.longstring_max_pattern_length,
+            na_rm=options.na_rm,
+        ),
         flag_direction="high",
         default_screen=True,
     ),
@@ -155,6 +290,12 @@ INDEX_REGISTRY: dict[str, IndexSpec] = {
         composite_multiplier=-1.0,
         default_screen=True,
         default_composite=True,
+    ),
+    "psychant": IndexSpec(
+        name="psychant",
+        scorer=_psychant_scores,
+        flag_direction="low",
+        composite_multiplier=-1.0,
     ),
     "person_total": IndexSpec(
         name="person_total",
@@ -183,7 +324,10 @@ INDEX_REGISTRY: dict[str, IndexSpec] = {
     "midpoint": IndexSpec(
         name="midpoint",
         scorer=lambda x, options: midpoint_responding(
-            x, scale_min=options.scale_min, scale_max=options.scale_max
+            x,
+            scale_min=options.scale_min,
+            scale_max=options.scale_max,
+            tolerance=options.midpoint_tolerance,
         ),
         flag_direction="high",
         default_screen=True,
@@ -191,11 +335,31 @@ INDEX_REGISTRY: dict[str, IndexSpec] = {
     ),
     "acquiescence": IndexSpec(
         name="acquiescence",
-        scorer=lambda x, options: acquiescence(
-            x, scale_min=options.scale_min, scale_max=options.scale_max, na_rm=options.na_rm
-        ),
+        scorer=_acquiescence_scores,
         flag_direction="high",
         default_screen=True,
+        composite_enabled=False,
+    ),
+    "guttman": IndexSpec(
+        name="guttman",
+        scorer=_guttman_scores,
+        flag_direction="high",
+        default_screen=True,
+        # Available in composite(), but not default: Guttman errors can dilute
+        # pattern-based signals like straightlining in small samples.
+        default_composite=False,
+    ),
+    "individual_reliability": IndexSpec(
+        name="individual_reliability",
+        scorer=_reliability_scores,
+        flag_direction="low",
+        composite_multiplier=-1.0,
+    ),
+    "onset": IndexSpec(
+        name="onset",
+        scorer=_onset_scores,
+        flag_direction="high",
+        flag_mode="present",
         composite_enabled=False,
     ),
     "evenodd": IndexSpec(
@@ -216,6 +380,26 @@ INDEX_REGISTRY: dict[str, IndexSpec] = {
         scorer=lambda x, options: lz(x, na_rm=options.na_rm),
         flag_direction="low",
         composite_multiplier=-1.0,
+    ),
+    "semantic_syn": IndexSpec(
+        name="semantic_syn",
+        scorer=_semantic_syn_scores,
+        flag_direction="low",
+        composite_multiplier=-1.0,
+        required_error=_require_semantic_pairs,
+    ),
+    "semantic_ant": IndexSpec(
+        name="semantic_ant",
+        scorer=_semantic_ant_scores,
+        flag_direction="low",
+        composite_multiplier=-1.0,
+        required_error=_require_semantic_pairs,
+    ),
+    "infrequency": IndexSpec(
+        name="infrequency",
+        scorer=_infrequency_scores,
+        flag_direction="high",
+        required_error=_require_infrequency_config,
     ),
 }
 
@@ -240,7 +424,7 @@ def validate_index_names(indices: list[str], allowed: set[str] | None = None) ->
     valid = set(INDEX_REGISTRY) if allowed is None else allowed
     for name in indices:
         if name not in valid:
-            raise ValueError(f"invalid index '{name}'. Valid options: {valid}")
+            raise ValueError(f"invalid index '{name}'. Valid options: {sorted(valid)}")
 
 
 def score_registered_indices(
@@ -266,7 +450,7 @@ def score_registered_indices(
 
         try:
             score = spec.scorer(x, options)
-        except ValueError as err:
+        except (ValueError, RuntimeError, TypeError) as err:
             errors[name] = str(err)
             continue
 

--- a/src/ier/composite.py
+++ b/src/ier/composite.py
@@ -103,6 +103,41 @@ def _combine_scores(
     raise ValueError("method must be 'mean', 'sum', or 'max'")
 
 
+def _composite_options(
+    na_rm: bool,
+    psychsyn_critval: float,
+    evenodd_factors: list[int] | None,
+    mad_positive_items: list[int] | None,
+    mad_negative_items: list[int] | None,
+    mad_scale_max: int | None,
+    *,
+    psychant_critval: float = -0.6,
+    guttman_normalize: bool = True,
+    reliability_n_splits: int = 100,
+    reliability_random_seed: int | None = None,
+    semantic_item_pairs: list[tuple[int, int]] | None = None,
+    infrequency_item_indices: list[int] | None = None,
+    infrequency_expected_responses: list[float] | None = None,
+    infrequency_proportion: bool = False,
+) -> IndexOptions:
+    return build_index_options(
+        na_rm,
+        psychsyn_critval,
+        evenodd_factors,
+        mad_positive_items,
+        mad_negative_items,
+        mad_scale_max,
+        psychant_critval=psychant_critval,
+        guttman_normalize=guttman_normalize,
+        reliability_n_splits=reliability_n_splits,
+        reliability_random_seed=reliability_random_seed,
+        semantic_item_pairs=semantic_item_pairs,
+        infrequency_item_indices=infrequency_item_indices,
+        infrequency_expected_responses=infrequency_expected_responses,
+        infrequency_proportion=infrequency_proportion,
+    )
+
+
 def composite(
     x: MatrixLike,
     indices: list[str] | None = None,
@@ -110,10 +145,18 @@ def composite(
     standardize: bool = True,
     na_rm: bool = True,
     psychsyn_critval: float = 0.6,
+    psychant_critval: float = -0.6,
     evenodd_factors: list[int] | None = None,
     mad_positive_items: list[int] | None = None,
     mad_negative_items: list[int] | None = None,
     mad_scale_max: int | None = None,
+    guttman_normalize: bool = True,
+    reliability_n_splits: int = 100,
+    reliability_random_seed: int | None = None,
+    semantic_item_pairs: list[tuple[int, int]] | None = None,
+    infrequency_item_indices: list[int] | None = None,
+    infrequency_expected_responses: list[float] | None = None,
+    infrequency_proportion: bool = False,
     return_diagnostics: bool = False,
 ) -> np.ndarray | tuple[np.ndarray, dict[str, str]]:
     """
@@ -123,24 +166,38 @@ def composite(
     and combines them into a single composite score. Higher composite scores
     indicate greater likelihood of careless responding.
 
+    The composite score is a sample-relative signal, not a calibrated probability
+    of careless responding. Prefer multi-index agreement and substantive review
+    over any single cutoff.
+
     Parameters:
     - x: A matrix of data where rows are individuals and columns are item responses.
-    - indices: List of indices to include. Options: "irv", "longstring", "mahad",
-              "psychsyn", "evenodd", "person_total", "lz", "mad", "markov",
-              "longstring_pattern". Default includes all except evenodd (which
-              requires factor specification) and mad (which requires item info).
+    - indices: List of indices to include. Options include: "irv", "longstring",
+              "mahad", "psychsyn", "psychant", "evenodd", "person_total", "lz",
+              "mad", "markov", "longstring_pattern", "guttman",
+              "individual_reliability", "semantic_syn", "semantic_ant",
+              "infrequency". Default includes NumPy-safe indices that do not
+              require extra config.
     - method: How to combine indices. "mean" (default), "sum", "max", or
               "best_subset" (overrides indices to ["mad", "irv", "longstring", "lz"],
               falling back to ["irv", "longstring", "lz"] if MAD item info not provided).
     - standardize: If True (default), standardize each index to z-scores before combining.
     - na_rm: Handle missing values in individual indices.
     - psychsyn_critval: Critical correlation value for psychometric synonyms (default 0.6).
+    - psychant_critval: Critical correlation value for psychometric antonyms (default -0.6).
     - evenodd_factors: Factor lengths for even-odd consistency. Required if "evenodd"
                       is in indices. List of integers where each integer is the number
                       of items in that factor (e.g., [5, 5, 5] for three 5-item scales).
     - mad_positive_items: Column indices for positively-worded items (for MAD index).
     - mad_negative_items: Column indices for negatively-worded items (for MAD index).
     - mad_scale_max: Maximum value of the response scale (for MAD index).
+    - guttman_normalize: If True, use Guttman error proportions instead of counts.
+    - reliability_n_splits: Split-half iterations for individual_reliability.
+    - reliability_random_seed: Optional seed for individual_reliability.
+    - semantic_item_pairs: Item pairs for semantic_syn / semantic_ant.
+    - infrequency_item_indices: Attention-check item column indices.
+    - infrequency_expected_responses: Expected responses for attention checks.
+    - infrequency_proportion: If True, return failure proportions for infrequency.
 
     Returns:
     - A numpy array of composite scores for each individual. Higher scores indicate
@@ -160,13 +217,21 @@ def composite(
         [-0.7, 1.5, -0.2]
     """
     x_array = validate_matrix_input(x, check_type=False)
-    options = build_index_options(
+    options = _composite_options(
         na_rm,
         psychsyn_critval,
         evenodd_factors,
         mad_positive_items,
         mad_negative_items,
         mad_scale_max,
+        psychant_critval=psychant_critval,
+        guttman_normalize=guttman_normalize,
+        reliability_n_splits=reliability_n_splits,
+        reliability_random_seed=reliability_random_seed,
+        semantic_item_pairs=semantic_item_pairs,
+        infrequency_item_indices=infrequency_item_indices,
+        infrequency_expected_responses=infrequency_expected_responses,
+        infrequency_proportion=infrequency_proportion,
     )
     selected_indices = _resolve_composite_indices(
         indices, method, mad_positive_items, mad_negative_items
@@ -195,10 +260,18 @@ def composite_flag(
     standardize: bool = True,
     na_rm: bool = True,
     psychsyn_critval: float = 0.6,
+    psychant_critval: float = -0.6,
     evenodd_factors: list[int] | None = None,
     mad_positive_items: list[int] | None = None,
     mad_negative_items: list[int] | None = None,
     mad_scale_max: int | None = None,
+    guttman_normalize: bool = True,
+    reliability_n_splits: int = 100,
+    reliability_random_seed: int | None = None,
+    semantic_item_pairs: list[tuple[int, int]] | None = None,
+    infrequency_item_indices: list[int] | None = None,
+    infrequency_expected_responses: list[float] | None = None,
+    infrequency_proportion: bool = False,
     return_diagnostics: bool = False,
 ) -> tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, dict[str, str]]:
     """
@@ -213,10 +286,18 @@ def composite_flag(
     - standardize: Standardize indices to z-scores before combining.
     - na_rm: Handle missing values.
     - psychsyn_critval: Critical value for psychometric synonyms.
+    - psychant_critval: Critical value for psychometric antonyms.
     - evenodd_factors: Factor structure for even-odd consistency.
     - mad_positive_items: Column indices for positively-worded items (for MAD index).
     - mad_negative_items: Column indices for negatively-worded items (for MAD index).
     - mad_scale_max: Maximum value of the response scale (for MAD index).
+    - guttman_normalize: If True, use Guttman error proportions instead of counts.
+    - reliability_n_splits: Split-half iterations for individual_reliability.
+    - reliability_random_seed: Optional seed for individual_reliability.
+    - semantic_item_pairs: Item pairs for semantic_syn / semantic_ant.
+    - infrequency_item_indices: Attention-check item column indices.
+    - infrequency_expected_responses: Expected responses for attention checks.
+    - infrequency_proportion: If True, return failure proportions for infrequency.
 
     Returns:
     - Tuple of (composite_scores, flags) where flags is True for suspected
@@ -235,10 +316,18 @@ def composite_flag(
         standardize=standardize,
         na_rm=na_rm,
         psychsyn_critval=psychsyn_critval,
+        psychant_critval=psychant_critval,
         evenodd_factors=evenodd_factors,
         mad_positive_items=mad_positive_items,
         mad_negative_items=mad_negative_items,
         mad_scale_max=mad_scale_max,
+        guttman_normalize=guttman_normalize,
+        reliability_n_splits=reliability_n_splits,
+        reliability_random_seed=reliability_random_seed,
+        semantic_item_pairs=semantic_item_pairs,
+        infrequency_item_indices=infrequency_item_indices,
+        infrequency_expected_responses=infrequency_expected_responses,
+        infrequency_proportion=infrequency_proportion,
         return_diagnostics=return_diagnostics,
     )
     if return_diagnostics:
@@ -262,10 +351,18 @@ def composite_summary(
     standardize: bool = True,
     na_rm: bool = True,
     psychsyn_critval: float = 0.6,
+    psychant_critval: float = -0.6,
     evenodd_factors: list[int] | None = None,
     mad_positive_items: list[int] | None = None,
     mad_negative_items: list[int] | None = None,
     mad_scale_max: int | None = None,
+    guttman_normalize: bool = True,
+    reliability_n_splits: int = 100,
+    reliability_random_seed: int | None = None,
+    semantic_item_pairs: list[tuple[int, int]] | None = None,
+    infrequency_item_indices: list[int] | None = None,
+    infrequency_expected_responses: list[float] | None = None,
+    infrequency_proportion: bool = False,
 ) -> CompositeSummary:
     """
     Calculate composite scores with detailed summary statistics.
@@ -277,10 +374,18 @@ def composite_summary(
     - standardize: Standardize before combining.
     - na_rm: Handle missing values.
     - psychsyn_critval: Critical value for psychometric synonyms.
+    - psychant_critval: Critical value for psychometric antonyms.
     - evenodd_factors: Factor structure for even-odd consistency.
     - mad_positive_items: Column indices for positively-worded items (for MAD index).
     - mad_negative_items: Column indices for negatively-worded items (for MAD index).
     - mad_scale_max: Maximum value of the response scale (for MAD index).
+    - guttman_normalize: If True, use Guttman error proportions instead of counts.
+    - reliability_n_splits: Split-half iterations for individual_reliability.
+    - reliability_random_seed: Optional seed for individual_reliability.
+    - semantic_item_pairs: Item pairs for semantic_syn / semantic_ant.
+    - infrequency_item_indices: Attention-check item column indices.
+    - infrequency_expected_responses: Expected responses for attention checks.
+    - infrequency_proportion: If True, return failure proportions for infrequency.
 
     Returns:
     - Dictionary with composite scores, individual index scores, and statistics.
@@ -292,13 +397,21 @@ def composite_summary(
         dict_keys(['composite', 'indices', 'mean', 'std', 'min', 'max', ...])
     """
     x_array = validate_matrix_input(x, check_type=False)
-    options = build_index_options(
+    options = _composite_options(
         na_rm,
         psychsyn_critval,
         evenodd_factors,
         mad_positive_items,
         mad_negative_items,
         mad_scale_max,
+        psychant_critval=psychant_critval,
+        guttman_normalize=guttman_normalize,
+        reliability_n_splits=reliability_n_splits,
+        reliability_random_seed=reliability_random_seed,
+        semantic_item_pairs=semantic_item_pairs,
+        infrequency_item_indices=infrequency_item_indices,
+        infrequency_expected_responses=infrequency_expected_responses,
+        infrequency_proportion=infrequency_proportion,
     )
     selected_indices = _resolve_composite_indices(
         indices, method, mad_positive_items, mad_negative_items
@@ -336,10 +449,18 @@ def composite_probability(
     method: CompositeMethod = "mean",
     na_rm: bool = True,
     psychsyn_critval: float = 0.6,
+    psychant_critval: float = -0.6,
     evenodd_factors: list[int] | None = None,
     mad_positive_items: list[int] | None = None,
     mad_negative_items: list[int] | None = None,
     mad_scale_max: int | None = None,
+    guttman_normalize: bool = True,
+    reliability_n_splits: int = 100,
+    reliability_random_seed: int | None = None,
+    semantic_item_pairs: list[tuple[int, int]] | None = None,
+    infrequency_item_indices: list[int] | None = None,
+    infrequency_expected_responses: list[float] | None = None,
+    infrequency_proportion: bool = False,
 ) -> np.ndarray:
     """
     Compute an uncalibrated logistic composite IER score.
@@ -356,10 +477,18 @@ def composite_probability(
     - method: How to combine indices ("mean", "sum", "max", or "best_subset").
     - na_rm: Handle missing values.
     - psychsyn_critval: Critical value for psychometric synonyms.
+    - psychant_critval: Critical value for psychometric antonyms.
     - evenodd_factors: Factor structure for even-odd consistency.
     - mad_positive_items: Column indices for positively-worded items (for MAD index).
     - mad_negative_items: Column indices for negatively-worded items (for MAD index).
     - mad_scale_max: Maximum value of the response scale (for MAD index).
+    - guttman_normalize: If True, use Guttman error proportions instead of counts.
+    - reliability_n_splits: Split-half iterations for individual_reliability.
+    - reliability_random_seed: Optional seed for individual_reliability.
+    - semantic_item_pairs: Item pairs for semantic_syn / semantic_ant.
+    - infrequency_item_indices: Attention-check item column indices.
+    - infrequency_expected_responses: Expected responses for attention checks.
+    - infrequency_proportion: If True, return failure proportions for infrequency.
 
     Returns:
     - A numpy array of uncalibrated logistic composite scores between 0 and 1
@@ -377,10 +506,18 @@ def composite_probability(
         standardize=True,
         na_rm=na_rm,
         psychsyn_critval=psychsyn_critval,
+        psychant_critval=psychant_critval,
         evenodd_factors=evenodd_factors,
         mad_positive_items=mad_positive_items,
         mad_negative_items=mad_negative_items,
         mad_scale_max=mad_scale_max,
+        guttman_normalize=guttman_normalize,
+        reliability_n_splits=reliability_n_splits,
+        reliability_random_seed=reliability_random_seed,
+        semantic_item_pairs=semantic_item_pairs,
+        infrequency_item_indices=infrequency_item_indices,
+        infrequency_expected_responses=infrequency_expected_responses,
+        infrequency_proportion=infrequency_proportion,
     )
     z_scores = z_scores_result[0] if isinstance(z_scores_result, tuple) else z_scores_result
 

--- a/src/ier/mahad.py
+++ b/src/ier/mahad.py
@@ -62,7 +62,7 @@ def mahad(
     Raises:
     - ValueError: If inputs are invalid (empty data, invalid confidence, etc.)
     - TypeError: If input is not a list or numpy array
-    - RuntimeError: If scipy is required but not available
+    - RuntimeError: If chi2 flagging is requested but SciPy is unavailable
 
     Example:
         >>> import numpy as np
@@ -84,8 +84,12 @@ def mahad(
     if method not in ["chi2", "iqr", "zscore"]:
         raise ValueError("method must be one of: 'chi2', 'iqr', 'zscore'")
 
-    if method == "chi2" and not SCIPY_AVAILABLE:
-        raise RuntimeError("scipy is required for chi2 method. Install with: pip install scipy")
+    # Distances are NumPy-only; SciPy is only needed for chi-squared flagging.
+    if flag and method == "chi2" and not SCIPY_AVAILABLE:
+        raise RuntimeError(
+            "scipy is required for chi2 flagging. "
+            "Install with: pip install 'insufficient-effort[full]'"
+        )
 
     if na_rm:
         all_nan_mask = np.isnan(x_array).all(axis=1)

--- a/src/ier/screen.py
+++ b/src/ier/screen.py
@@ -24,34 +24,68 @@ def screen(
     na_rm: bool = True,
     percentile: float = 95.0,
     psychsyn_critval: float = 0.6,
+    psychant_critval: float = -0.6,
     evenodd_factors: list[int] | None = None,
     mad_positive_items: list[int] | None = None,
     mad_negative_items: list[int] | None = None,
     mad_scale_max: int | None = None,
     scale_min: float | None = None,
     scale_max: float | None = None,
+    acquiescence_positive_items: list[int] | None = None,
+    acquiescence_negative_items: list[int] | None = None,
+    longstring_max_pattern_length: int = 5,
+    midpoint_tolerance: float = 0.0,
+    guttman_normalize: bool = True,
+    onset_window_size: int = 10,
+    onset_min_items: int = 20,
+    reliability_n_splits: int = 100,
+    reliability_random_seed: int | None = None,
+    semantic_item_pairs: list[tuple[int, int]] | None = None,
+    infrequency_item_indices: list[int] | None = None,
+    infrequency_expected_responses: list[float] | None = None,
+    infrequency_proportion: bool = False,
 ) -> ScreenResult:
     """
     Screen respondents across multiple IER detection indices.
 
     Computes each requested index, flags outliers using percentile-based
-    thresholds, and returns structured results.
+    thresholds (or presence detection for onset), and returns structured results.
+
+    Default indices are NumPy-only and do not require SciPy. Response-time indices
+    are not included here because they use a different input domain; call them
+    directly.
 
     Parameters:
     - x: A matrix of data where rows are individuals and columns are item responses.
-    - indices: List of indices to compute. If None, uses defaults (indices not
-              requiring extra config). Options: "irv", "longstring", "longstring_pattern",
-              "mahad", "psychsyn", "person_total", "markov", "u3_poly", "midpoint",
-              "acquiescence", "evenodd", "mad", "lz".
+    - indices: List of indices to compute. If None, uses defaults that do not
+              require extra config. Registered options include: "irv", "longstring",
+              "longstring_pattern", "mahad", "psychsyn", "psychant", "person_total",
+              "markov", "u3_poly", "midpoint", "acquiescence", "guttman",
+              "individual_reliability", "onset", "evenodd", "mad", "lz",
+              "semantic_syn", "semantic_ant", "infrequency".
     - na_rm: Handle missing values in individual indices.
     - percentile: Percentile cutoff for flagging (default 95th).
     - psychsyn_critval: Critical correlation value for psychometric synonyms.
+    - psychant_critval: Critical correlation value for psychometric antonyms.
     - evenodd_factors: Factor lengths for even-odd consistency.
     - mad_positive_items: Column indices for positively-worded items (for MAD).
     - mad_negative_items: Column indices for negatively-worded items (for MAD).
     - mad_scale_max: Maximum value of response scale (for MAD).
     - scale_min: Minimum value of response scale (for u3_poly, midpoint, acquiescence).
     - scale_max: Maximum value of response scale (for u3_poly, midpoint, acquiescence).
+    - acquiescence_positive_items: Positive items for balanced-pair acquiescence.
+    - acquiescence_negative_items: Negative items for balanced-pair acquiescence.
+    - longstring_max_pattern_length: Max repeating-pattern length for longstring_pattern.
+    - midpoint_tolerance: Tolerance around scale midpoint for midpoint responding.
+    - guttman_normalize: If True, return Guttman error proportions instead of counts.
+    - onset_window_size: Sliding window size for onset detection.
+    - onset_min_items: Minimum items required for onset detection.
+    - reliability_n_splits: Split-half iterations for individual_reliability.
+    - reliability_random_seed: Optional seed for individual_reliability.
+    - semantic_item_pairs: Item pairs for semantic_syn / semantic_ant.
+    - infrequency_item_indices: Attention-check item column indices.
+    - infrequency_expected_responses: Expected responses for attention checks.
+    - infrequency_proportion: If True, return failure proportions for infrequency.
 
     Returns:
     - Dictionary with:
@@ -60,6 +94,7 @@ def screen(
         - "flag_counts": array of total flags per respondent
         - "n_indices": number of indices successfully computed
         - "indices_used": list of index names computed
+        - "errors": dict mapping failed index names to error messages
         - "n_respondents": number of respondents
         - "summary": dict mapping index name to summary statistics
 
@@ -89,11 +124,30 @@ def screen(
         mad_scale_max,
         scale_min=scale_min,
         scale_max=scale_max,
+        psychant_critval=psychant_critval,
+        acquiescence_positive_items=acquiescence_positive_items,
+        acquiescence_negative_items=acquiescence_negative_items,
+        longstring_max_pattern_length=longstring_max_pattern_length,
+        midpoint_tolerance=midpoint_tolerance,
+        guttman_normalize=guttman_normalize,
+        onset_window_size=onset_window_size,
+        onset_min_items=onset_min_items,
+        reliability_n_splits=reliability_n_splits,
+        reliability_random_seed=reliability_random_seed,
+        semantic_item_pairs=semantic_item_pairs,
+        infrequency_item_indices=infrequency_item_indices,
+        infrequency_expected_responses=infrequency_expected_responses,
+        infrequency_proportion=infrequency_proportion,
     )
     scores, errors = score_registered_indices(x_array, indices, options)
 
     flags: dict[str, np.ndarray] = {}
     for name, score_arr in scores.items():
+        spec = INDEX_REGISTRY[name]
+        if spec.flag_mode == "present":
+            flags[name] = ~np.isnan(score_arr)
+            continue
+
         valid_scores = score_arr[~np.isnan(score_arr)]
         if len(valid_scores) == 0:
             flags[name] = np.zeros(n_respondents, dtype=bool)
@@ -104,7 +158,7 @@ def screen(
         flag_arr = np.zeros(n_respondents, dtype=bool)
         valid_mask = ~np.isnan(score_arr)
 
-        if INDEX_REGISTRY[name].flag_direction == "high":
+        if spec.flag_direction == "high":
             flag_arr[valid_mask] = score_arr[valid_mask] > cutoff
         else:
             low_cutoff = float(np.percentile(valid_scores, 100.0 - percentile))

--- a/tests/test_screening_workflow.py
+++ b/tests/test_screening_workflow.py
@@ -1,10 +1,13 @@
 """Unit tests for acquiescence, screening, and visualization functions."""
 
 import unittest
+from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from ier.acquiescence import acquiescence, acquiescence_flag
+from ier.mahad import mahad
 from ier.screen import screen
 from ier.visualize import plot_distributions, plot_flag_counts, plot_flagged_heatmap
 
@@ -186,6 +189,74 @@ class TestScreen(unittest.TestCase):
         result = screen(self.data)
         for name, flags in result["flags"].items():
             self.assertEqual(len(flags), 30, f"flag length mismatch for {name}")
+
+    def test_default_includes_guttman_and_mahad(self) -> None:
+        result = screen(self.data)
+        self.assertIn("guttman", result["indices_used"])
+        self.assertIn("mahad", result["indices_used"])
+        self.assertEqual(result["errors"], {})
+
+    def test_new_registered_indices_with_config(self) -> None:
+        result = screen(
+            self.data,
+            indices=["guttman", "semantic_syn", "infrequency", "individual_reliability"],
+            semantic_item_pairs=[(0, 1), (2, 3)],
+            infrequency_item_indices=[0],
+            infrequency_expected_responses=[3.0],
+            reliability_n_splits=5,
+            reliability_random_seed=0,
+        )
+        self.assertEqual(
+            set(result["indices_used"]),
+            {"guttman", "semantic_syn", "infrequency", "individual_reliability"},
+        )
+        self.assertEqual(result["errors"], {})
+
+    def test_missing_semantic_and_infrequency_config_in_errors(self) -> None:
+        result = screen(self.data, indices=["semantic_syn", "infrequency"])
+        self.assertIn("semantic_syn", result["errors"])
+        self.assertIn("infrequency", result["errors"])
+
+    def test_onset_present_flag_mode(self) -> None:
+        rng = np.random.default_rng(0)
+        attentive = rng.choice([1, 2, 3, 4, 5], size=(5, 20))
+        careless = np.full((5, 20), 3.0)
+        data = np.hstack([attentive, careless])
+        result = screen(
+            data,
+            indices=["onset"],
+            onset_window_size=5,
+            onset_min_items=10,
+        )
+        self.assertIn("onset", result["indices_used"])
+        self.assertEqual(result["flags"]["onset"].dtype, bool)
+
+    def test_mahad_distances_without_scipy(self) -> None:
+        with patch("ier.mahad.SCIPY_AVAILABLE", False):
+            distances = mahad(self.data, method="chi2")
+        self.assertEqual(len(distances), 30)
+
+
+class TestDataFrameInputs(unittest.TestCase):
+    """Smoke tests for pandas/polars array-compatible inputs."""
+
+    def test_pandas_dataframe(self) -> None:
+        pd = pytest.importorskip("pandas")
+        from ier import irv, screen
+
+        df = pd.DataFrame(np.array([[1, 2, 3, 4, 5], [3, 3, 3, 3, 3]], dtype=float))
+        scores = irv(df)
+        self.assertEqual(len(scores), 2)
+        result = screen(df, indices=["irv", "longstring"])
+        self.assertEqual(result["n_respondents"], 2)
+
+    def test_polars_dataframe(self) -> None:
+        pl = pytest.importorskip("polars")
+        from ier import irv
+
+        df = pl.DataFrame({"a": [1.0, 3.0], "b": [2.0, 3.0], "c": [3.0, 3.0], "d": [4.0, 3.0]})
+        scores = irv(df.to_numpy())
+        self.assertEqual(len(scores), 2)
 
 
 class TestPlotDistributions(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,28 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -163,6 +185,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
     { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -471,6 +505,27 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.152.4"
 source = { registry = "https://pypi.org/simple" }
@@ -511,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "insufficient-effort"
-version = "1.6.3"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -522,9 +577,14 @@ dev = [
     { name = "bandit" },
     { name = "hypothesis" },
     { name = "matplotlib" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
+    { name = "pandas" },
     { name = "pillow" },
     { name = "pip-audit" },
+    { name = "polars" },
     { name = "pre-commit" },
     { name = "pygments" },
     { name = "pylint" },
@@ -534,6 +594,11 @@ dev = [
     { name = "ruff" },
     { name = "scipy" },
     { name = "scipy-stubs" },
+]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
 ]
 full = [
     { name = "scipy" },
@@ -548,10 +613,18 @@ requires-dist = [
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.150.0,<7" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.8.0,<4" },
     { name = "matplotlib", marker = "extra == 'plot'", specifier = ">=3.8.0,<4" },
+    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0,<2" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0,<2" },
+    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.0,<10" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0,<10" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.26.0,<1" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.26.0,<1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0,<3" },
     { name = "numpy", specifier = ">=1.26.0,<2.5" },
+    { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.2.0,<3" },
     { name = "pillow", marker = "extra == 'dev'", specifier = ">=12.2.0,<13" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.9.0,<3" },
+    { name = "polars", marker = "extra == 'dev'", specifier = ">=1.0.0,<2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0,<5" },
     { name = "pygments", marker = "extra == 'dev'", specifier = ">=2.20.0,<3" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=4.0.0,<5" },
@@ -563,7 +636,7 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'full'", specifier = ">=1.11.0,<1.18" },
     { name = "scipy-stubs", marker = "extra == 'dev'", specifier = ">=1.16.3,<1.18" },
 ]
-provides-extras = ["full", "plot", "dev"]
+provides-extras = ["full", "plot", "docs", "dev"]
 
 [[package]]
 name = "isort"
@@ -572,6 +645,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -766,6 +851,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -775,6 +869,80 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -857,6 +1025,134 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "0.30.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/33/2fa3243439f794e685d3e694590d28469a9b8ea733af4b48c250a3ffc9a0/mkdocstrings-0.30.1.tar.gz", hash = "sha256:84a007aae9b707fb0aebfc9da23db4b26fc9ab562eb56e335e9ec480cb19744f", size = 106350, upload-time = "2025-09-19T10:49:26.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl", hash = "sha256:41bd71f284ca4d44a668816193e4025c950b002252081e387433656ae9a70a82", size = 36704, upload-time = "2025-09-19T10:49:24.805Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
 ]
 
 [[package]]
@@ -1120,6 +1416,69 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1287,6 +1646,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/5b/5d0f0aa53c6e9a8ecbc99ff502edcf9584e5d08ab34ea407c086999103d5/polars-1.43.0.tar.gz", hash = "sha256:bb2c67553e4968c18dfe268a88ff9a5790d5c2e0b7ea7efe97640b9a90438c88", size = 749537, upload-time = "2026-07-21T04:30:25.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/28/a8eac2c1d1b2d2a4ba2eb745921616d863185d94b1afd91cbb07af9ef21a/polars-1.43.0-py3-none-any.whl", hash = "sha256:c49078b14e2d6b8ff5cc5b78b6d9638603ea5dffafb889d9204818822f55b813", size = 846493, upload-time = "2026-07-21T04:29:06.68Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/96/7e714cad082e9e6aaebb8886fcb1b0220d5c35149d4c8d3466bd7e7d581e/polars_runtime_32-1.43.0.tar.gz", hash = "sha256:5fb47a3a883402e62eab2fde5922f78c531d037aeece3640c15225f39228621e", size = 3090044, upload-time = "2026-07-21T04:30:27.185Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/14/9b1f5eb1c5104ba1ceb380a7308ffcd979f3ce1df86e76293062698f2ff1/polars_runtime_32-1.43.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6707193d30a7135bce0424304f76d8145270527444097548e794ad8d26823b70", size = 53059463, upload-time = "2026-07-21T04:29:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/73d77d1c0c928eb599d9516d874af0cd2b6225201e1327a6c4857e6776d0/polars_runtime_32-1.43.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:78ca2f97740b2a6beb36eb112749280b5e08750c60f53c08d2feffebdba9d35a", size = 47499586, upload-time = "2026-07-21T04:29:13.229Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b1/98278fa796f93d0975fd3fe1d4ab4031707d4a9f1da44c21c29996b62c73/polars_runtime_32-1.43.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ffa99bb2c7ee0a9392ae50b350af0ed17acf0519d15c75fe223021798566174", size = 51326702, upload-time = "2026-07-21T04:29:16.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/7d/24ae73389aac03296925973c4e2cbe2e4982e859b9fad69eb1a72b9026fa/polars_runtime_32-1.43.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ecc8feaf04de5989a29245885921db612ef1ce9065e5cb6ec37495acfa55bba", size = 57266705, upload-time = "2026-07-21T04:29:19.288Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/2026be1f7b51242ad62e08b20728462558e161fb84b564e5b986f2b38664/polars_runtime_32-1.43.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:01e1471a5ee161a969c7a96991d8e5d20b97a0b7fe075df9c7a01f52a49c5ac2", size = 51484129, upload-time = "2026-07-21T04:29:22.639Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/047c7695f08a9b18614c0e1ec5e70a754455542a21a6d52955f7f05c6268/polars_runtime_32-1.43.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9cd8b813afe67d59e87027dedcaf5c6a06fe602472fd74e1a49f4bafea47259c", size = 55169401, upload-time = "2026-07-21T04:29:25.902Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/bfd2533c487563c7a21ab7d7af3d78f820b0236e14dc5ee63d46188cd275/polars_runtime_32-1.43.0-cp310-abi3-win_amd64.whl", hash = "sha256:41a75fb3cb4cc574eb21801383578f75cfc374597c22322ef457ab7bac8a3301", size = 52541527, upload-time = "2026-07-21T04:29:29.162Z" },
+    { url = "https://files.pythonhosted.org/packages/46/d7/5c47f1bf57479d1671669af9c421f9abf4986b2ddaa64c177244ff811de0/polars_runtime_32-1.43.0-cp310-abi3-win_arm64.whl", hash = "sha256:c285e598dd91e08560e519275b8b8108adbafb438d218a175ebe073dbc2027fb", size = 46552281, upload-time = "2026-07-21T04:29:32.224Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1339,6 +1726,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -1406,6 +1806,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1458,6 +1867,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -1705,6 +2126,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1726,4 +2156,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
## Summary
- Make default `screen()` / `composite()` NumPy-safe and register remaining matrix indices (`guttman`, `psychant`, `individual_reliability`, `onset`, `semantic_*`, `infrequency`)
- Add MkDocs docs, curated changelog, examples, and a `screen()` benchmark; bump package to 1.7.0
- Tighten CI (coverage 90%, Bandit, Codecov) and add pandas/polars smoke tests plus a docs Pages workflow

## Test plan
- [ ] `uv sync --extra dev && uv run pytest tests/ -v --cov=ier --cov-fail-under=90`
- [ ] `uv run ruff check . && uv run mypy src/ier && uv run bandit -r src/ier -c pyproject.toml`
- [ ] `uv run mkdocs build --strict`
- [ ] `uv run python examples/basic_screening.py`
- [ ] Confirm default `screen()` works without SciPy; `mahad(..., flag=True, method="chi2")` still requires `[full]`


Made with [Cursor](https://cursor.com)